### PR TITLE
API 3060 rules

### DIFF
--- a/spotbugs-excludes.xml
+++ b/spotbugs-excludes.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
-  <!-- [ERROR] Synchronization performed on java.util.concurrent.atomic.AtomicReference in gov.va.api.lighthouse.vulcan.DateMapping$SearchableDate.fidelity() [gov.va.api.lighthouse.vulcan.DateMapping$SearchableDate] At DateMapping.java:[line 235] JLM_JSR166_UTILCONCURRENT_MONITORENTER -->
+  <!-- [ERROR] Synchronization performed on java.util.concurrent.atomic.AtomicReference in gov.va.api.lighthouse.vulcan.mappings.DateMapping$SearchableDate.fidelity() [gov.va.api.lighthouse.vulcan.mappings.DateMapping$SearchableDate] At DateMapping.java:[line 235] JLM_JSR166_UTILCONCURRENT_MONITORENTER -->
   <!--
     Lombok generated lazy getters
   -->
   <Match>
-    <Class name="gov.va.api.lighthouse.vulcan.DateMapping$SearchableDate"/>
+    <Class name="gov.va.api.lighthouse.vulcan.mappings.DateMapping$SearchableDate"/>
     <Bug pattern="JLM_JSR166_UTILCONCURRENT_MONITORENTER"/>
   </Match>
 </FindBugsFilter>

--- a/src/main/java/gov/va/api/lighthouse/vulcan/CircuitBreaker.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/CircuitBreaker.java
@@ -6,9 +6,13 @@ package gov.va.api.lighthouse.vulcan;
  * the database that no results will be found.
  */
 public class CircuitBreaker extends RuntimeException {
-
   public CircuitBreaker(String message) {
     super(message);
+  }
+
+  /** Create a new exception for a parameter that has been repeated to much. */
+  public static CircuitBreaker noParametersSpecified() {
+    return new CircuitBreaker("No parameters specified.");
   }
 
   /** Create a new exception for bad value, like a number that cannot be parsed. */

--- a/src/main/java/gov/va/api/lighthouse/vulcan/CircuitBreaker.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/CircuitBreaker.java
@@ -1,0 +1,20 @@
+package gov.va.api.lighthouse.vulcan;
+
+/**
+ * This exception can be thrown by Mapping instance when attempting to build specifications to short
+ * circuit searching the database. This exception means that we already know, even before searching
+ * the database that no results will be found.
+ */
+public class CircuitBreaker extends RuntimeException {
+
+  public CircuitBreaker(String message) {
+    super(message);
+  }
+
+  /** Create a new exception for bad value, like a number that cannot be parsed. */
+  public static CircuitBreaker noResultsWillBeFound(
+      String parameter, String value, String message) {
+    return new CircuitBreaker(
+        String.format("No results will be found for %s = %s : %s", parameter, value, message));
+  }
+}

--- a/src/main/java/gov/va/api/lighthouse/vulcan/InvalidParameter.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/InvalidParameter.java
@@ -19,6 +19,11 @@ public class InvalidParameter extends IllegalArgumentException {
   }
 
   /** Create a new exception for a parameter that has been repeated to much. */
+  public static InvalidParameter noParametersSpecified() {
+    return new InvalidParameter("No parameters specified.");
+  }
+
+  /** Create a new exception for a parameter that has been repeated to much. */
   public static InvalidParameter repeatedTooManyTimes(String parameter, int max, int actual) {
     return new InvalidParameter(
         String.format(

--- a/src/main/java/gov/va/api/lighthouse/vulcan/InvalidParameter.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/InvalidParameter.java
@@ -1,9 +1,13 @@
 package gov.va.api.lighthouse.vulcan;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 /**
  * Indicate there parameter is not valid. This would indicate that a 404 Bad Request should be
  * returned to the user.
  */
+@ResponseStatus(code = HttpStatus.BAD_REQUEST)
 public class InvalidParameter extends IllegalArgumentException {
   public InvalidParameter(String message) {
     super(message);

--- a/src/main/java/gov/va/api/lighthouse/vulcan/InvalidRequest.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/InvalidRequest.java
@@ -15,18 +15,25 @@ public class InvalidRequest extends IllegalArgumentException {
 
   /** Create a new exception for bad value, like a number that cannot be parsed. */
   public static InvalidRequest badParameter(String parameter, String value, String message) {
-    return new InvalidRequest(String.format("%s = %s : %s", parameter, value, message));
+    return because("bad parameter: %s = %s : %s", parameter, value, message);
+  }
+
+  public static InvalidRequest because(String message) {
+    return new InvalidRequest(message);
+  }
+
+  @SuppressWarnings("AnnotateFormatMethod")
+  public static InvalidRequest because(String format, Object... messageValues) {
+    return new InvalidRequest(String.format(format, messageValues));
   }
 
   /** Create a new exception for a parameter that has been repeated to much. */
   public static InvalidRequest noParametersSpecified() {
-    return new InvalidRequest("No parameters specified.");
+    return because("No parameters specified.");
   }
 
   /** Create a new exception for a parameter that has been repeated to much. */
   public static InvalidRequest repeatedTooManyTimes(String parameter, int max, int actual) {
-    return new InvalidRequest(
-        String.format(
-            "%s specified too many %d times, up to %d is allowed", parameter, actual, max));
+    return because("%s specified too many %d times, up to %d is allowed", parameter, actual, max);
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/InvalidRequest.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/InvalidRequest.java
@@ -8,24 +8,24 @@ import org.springframework.web.bind.annotation.ResponseStatus;
  * returned to the user.
  */
 @ResponseStatus(code = HttpStatus.BAD_REQUEST)
-public class InvalidParameter extends IllegalArgumentException {
-  public InvalidParameter(String message) {
+public class InvalidRequest extends IllegalArgumentException {
+  public InvalidRequest(String message) {
     super(message);
   }
 
   /** Create a new exception for bad value, like a number that cannot be parsed. */
-  public static InvalidParameter badValue(String parameter, String value, String message) {
-    return new InvalidParameter(String.format("%s = %s : %s", parameter, value, message));
+  public static InvalidRequest badParameter(String parameter, String value, String message) {
+    return new InvalidRequest(String.format("%s = %s : %s", parameter, value, message));
   }
 
   /** Create a new exception for a parameter that has been repeated to much. */
-  public static InvalidParameter noParametersSpecified() {
-    return new InvalidParameter("No parameters specified.");
+  public static InvalidRequest noParametersSpecified() {
+    return new InvalidRequest("No parameters specified.");
   }
 
   /** Create a new exception for a parameter that has been repeated to much. */
-  public static InvalidParameter repeatedTooManyTimes(String parameter, int max, int actual) {
-    return new InvalidParameter(
+  public static InvalidRequest repeatedTooManyTimes(String parameter, int max, int actual) {
+    return new InvalidRequest(
         String.format(
             "%s specified too many %d times, up to %d is allowed", parameter, actual, max));
   }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Mappings.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Mappings.java
@@ -88,7 +88,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
 
   /** Create a value mapping where request and field name are the same with no value conversion. */
   public Mappings<EntityT> value(String parameterAndFieldName) {
-    return value(parameterAndFieldName, parameterAndFieldName, Function.identity());
+    return value(parameterAndFieldName, parameterAndFieldName);
   }
 
   /**

--- a/src/main/java/gov/va/api/lighthouse/vulcan/RequestContext.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/RequestContext.java
@@ -116,11 +116,13 @@ public class RequestContext<EntityT> {
   }
 
   private Specification<EntityT> specificationOf(HttpServletRequest request) {
-    return config.mappings().stream()
-        .filter(m -> m.appliesTo(request))
-        .peek(m -> log.info("Applying {}", m))
-        .map(m -> m.specificationFor(request))
-        .filter(Objects::nonNull)
-        .collect(Specifications.all());
+    Specification<EntityT> all =
+        config.mappings().stream()
+            .filter(m -> m.appliesTo(request))
+            .peek(m -> log.info("Applying {}", m))
+            .map(m -> m.specificationFor(request))
+            .filter(Objects::nonNull)
+            .collect(Specifications.all());
+    return all == null ? config.defaultQuery().apply(request) : all;
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/RequestContext.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/RequestContext.java
@@ -121,6 +121,6 @@ public class RequestContext<EntityT> {
         .filter(m -> m.appliesTo(request))
         .peek(m -> log.info("Applying {}", m))
         .map(m -> m.specificationFor(request))
-        .collect(Specifications.and());
+        .collect(Specifications.all());
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rule.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rule.java
@@ -1,0 +1,17 @@
+package gov.va.api.lighthouse.vulcan;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Instances are applied to request object and have the opportunity to reject the request by
+ * throwing an instance of InvalidRequest exception.
+ */
+@FunctionalInterface
+public interface Rule {
+
+  /**
+   * Check some aspect of the request and thrown an InvalidRequest exception if some condition is
+   * not satisfied, e.g., a required parameter is not set.
+   */
+  void check(HttpServletRequest request);
+}

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
@@ -1,0 +1,106 @@
+package gov.va.api.lighthouse.vulcan;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.UtilityClass;
+
+/**
+ * This provides some standard rules for HTTP request validation. If a rule fails and invalid
+ * request exception will be thrown.
+ */
+@UtilityClass
+public class Rules {
+
+  /** Requires that at least on of the parameters be specified. */
+  public Rule atLeastOneParameterOf(String... parameter) {
+    return (r) -> {
+      for (String p : parameter) {
+        if (r.getParameter(p) != null) {
+          return;
+        }
+      }
+      throw InvalidRequest.because(
+          "At least one of %s must be specified", Arrays.toString(parameter));
+    };
+  }
+
+  /** Requires that none of these parameters be specified. */
+  public Rule forbiddenParameters(String... parameter) {
+    return (r) -> {
+      for (String p : parameter) {
+        if (r.getParameter(p) != null) {
+          throw InvalidRequest.because(
+              "No parameter of %s can be specified", Arrays.toString(parameter));
+        }
+      }
+    };
+  }
+
+  /**
+   * Create a rule with conditional behavior to be specified if a given parameter is specified in
+   * the request.
+   */
+  public IfParameterRuleBuilder ifParameter(String parameter) {
+    return new IfParameterRuleBuilder(parameter);
+  }
+
+  /**
+   * Create a rule that requires certain parameters to be specified together, e.g. latitude and
+   * longitude.
+   */
+  public Rule parametersAlwaysSpecifiedTogether(String... parameter) {
+    return (r) -> {
+      int specified = 0;
+      for (String p : parameter) {
+        if (r.getParameter(p) != null) {
+          specified++;
+        }
+      }
+      if (specified > 0 && specified != parameter.length) {
+        throw InvalidRequest.because(
+            "Parameters %s must be specified together", Arrays.toString(parameter));
+      }
+    };
+  }
+
+  /** Create a rule that prevents parameters from being specified together. */
+  public Rule parametersNeverSpecifiedTogether(String... parameter) {
+    return (r) -> {
+      int specified = 0;
+      for (String p : parameter) {
+        if (r.getParameter(p) != null) {
+          specified++;
+        }
+      }
+      if (specified > 0 && specified != 1) {
+        throw InvalidRequest.because(
+            "Parameters %s cannot be specified together", Arrays.toString(parameter));
+      }
+    };
+  }
+
+  @RequiredArgsConstructor
+  public static class IfParameterRuleBuilder {
+    private final String parameter;
+
+    /** Require at least one of the given parameters to be specified. */
+    public Rule thenAlsoAtLeastOneParameterOf(String... requiredParameters) {
+      return (r) -> {
+        if (isNotBlank(r.getParameter(parameter))) {
+          atLeastOneParameterOf(requiredParameters).check(r);
+        }
+      };
+    }
+
+    /** Forbid all of the given parameters from being specified. */
+    public Rule thenForbidParameters(String... forbiddenParameters) {
+      return (r) -> {
+        if (isNotBlank(r.getParameter(parameter))) {
+          forbiddenParameters(forbiddenParameters).check(r);
+        }
+      };
+    }
+  }
+}

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
@@ -15,7 +15,7 @@ public class Specifications {
   /** Produces a specification than explicitly handles a lists of 0 and 1. */
   public static <E> Specification<E> selectInList(String fieldName, Collection<String> values) {
     if (values == null || values.isEmpty()) {
-      return (root, criteriaQuery, criteriaBuilder) -> null;
+      return null;
     }
     if (values.size() == 1) {
       return (root, criteriaQuery, criteriaBuilder) ->

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
@@ -1,7 +1,9 @@
 package gov.va.api.lighthouse.vulcan;
 
+import java.util.Collection;
 import java.util.stream.Collector;
 import java.util.stream.Collector.Characteristics;
+import javax.persistence.criteria.CriteriaBuilder.In;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import org.springframework.data.jpa.domain.Specification;
@@ -10,18 +12,47 @@ import org.springframework.data.jpa.domain.Specification;
 @UtilityClass
 public class Specifications {
 
-  public static <E> Specification<E> selectNothing() {
-    return (root, query, builder) -> null;
+  /** Produces a specification than explicitly handles a lists of 0 and 1. */
+  public static <E> Specification<E> selectInList(String fieldName, Collection<String> values) {
+    if (values == null || values.isEmpty()) {
+      return (root, criteriaQuery, criteriaBuilder) -> null;
+    }
+    if (values.size() == 1) {
+      return (root, criteriaQuery, criteriaBuilder) ->
+          criteriaBuilder.equal(root.get(fieldName), values.stream().findFirst().orElseThrow());
+    }
+    return (root, criteriaQuery, criteriaBuilder) -> {
+      In<String> in = criteriaBuilder.in(root.get(fieldName));
+      values.forEach(in::value);
+      return criteriaBuilder.or(in);
+    };
   }
 
-  /** Create a Stream collector for Specifications. */
+  /**
+   * Create a Stream collector for Specifications where the final form must match all specifications
+   * that were collected.
+   */
   public static <E>
-      Collector<Specification<E>, MatchesAllSpecifications<E>, Specification<E>> and() {
+      Collector<Specification<E>, MatchesAllSpecifications<E>, Specification<E>> all() {
     return Collector.of(
         MatchesAllSpecifications::new,
         MatchesAllSpecifications::add,
         (a, b) -> a.add(b.specification()),
         MatchesAllSpecifications::specification,
+        Characteristics.UNORDERED);
+  }
+
+  /**
+   * Create a Stream collector for Specifications where the final form must match any specifications
+   * that were collected.
+   */
+  public static <E>
+      Collector<Specification<E>, MatchesAnySpecifications<E>, Specification<E>> any() {
+    return Collector.of(
+        MatchesAnySpecifications::new,
+        MatchesAnySpecifications::add,
+        (a, b) -> a.add(b.specification()),
+        MatchesAnySpecifications::specification,
         Characteristics.UNORDERED);
   }
 
@@ -34,6 +65,21 @@ public class Specifications {
           specification = andMe;
         } else {
           specification = specification.and(andMe);
+        }
+      }
+      return this;
+    }
+  }
+
+  private static class MatchesAnySpecifications<E> {
+    @Getter Specification<E> specification;
+
+    MatchesAnySpecifications<E> add(Specification<E> andMe) {
+      if (andMe != null) {
+        if (specification == null) {
+          specification = andMe;
+        } else {
+          specification = specification.or(andMe);
         }
       }
       return this;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
@@ -11,23 +11,6 @@ import org.springframework.data.jpa.domain.Specification;
 /** Utilities for specifications. */
 @UtilityClass
 public class Specifications {
-
-  /** Produces a specification than explicitly handles a lists of 0 and 1. */
-  public static <E> Specification<E> selectInList(String fieldName, Collection<String> values) {
-    if (values == null || values.isEmpty()) {
-      return null;
-    }
-    if (values.size() == 1) {
-      return (root, criteriaQuery, criteriaBuilder) ->
-          criteriaBuilder.equal(root.get(fieldName), values.stream().findFirst().orElseThrow());
-    }
-    return (root, criteriaQuery, criteriaBuilder) -> {
-      In<String> in = criteriaBuilder.in(root.get(fieldName));
-      values.forEach(in::value);
-      return criteriaBuilder.or(in);
-    };
-  }
-
   /**
    * Create a Stream collector for Specifications where the final form must match all specifications
    * that were collected.
@@ -54,6 +37,22 @@ public class Specifications {
         (a, b) -> a.add(b.specification()),
         MatchesAnySpecifications::specification,
         Characteristics.UNORDERED);
+  }
+
+  /** Produces a specification than explicitly handles a lists of 0 and 1. */
+  public static <E> Specification<E> selectInList(String fieldName, Collection<String> values) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    if (values.size() == 1) {
+      return (root, criteriaQuery, criteriaBuilder) ->
+          criteriaBuilder.equal(root.get(fieldName), values.stream().findFirst().orElseThrow());
+    }
+    return (root, criteriaQuery, criteriaBuilder) -> {
+      In<String> in = criteriaBuilder.in(root.get(fieldName));
+      values.forEach(in::value);
+      return criteriaBuilder.or(in);
+    };
   }
 
   private static class MatchesAllSpecifications<E> {

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
@@ -10,6 +10,10 @@ import org.springframework.data.jpa.domain.Specification;
 @UtilityClass
 public class Specifications {
 
+  public static <E> Specification<E> selectNothing() {
+    return (root, query, builder) -> null;
+  }
+
   /** Create a Stream collector for Specifications. */
   public static <E>
       Collector<Specification<E>, MatchesAllSpecifications<E>, Specification<E>> and() {

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
@@ -73,12 +73,12 @@ public class Specifications {
   private static class MatchesAnySpecifications<E> {
     @Getter Specification<E> specification;
 
-    MatchesAnySpecifications<E> add(Specification<E> andMe) {
-      if (andMe != null) {
+    MatchesAnySpecifications<E> add(Specification<E> orMe) {
+      if (orMe != null) {
         if (specification == null) {
-          specification = andMe;
+          specification = orMe;
         } else {
-          specification = specification.or(andMe);
+          specification = specification.or(orMe);
         }
       }
       return this;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Vulcan.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Vulcan.java
@@ -32,7 +32,7 @@ public class Vulcan<EntityT, JpaRepositoryT extends JpaSpecificationExecutor<Ent
   /** Default query option that throws an InvalidParameter exception. */
   public static <E> Function<HttpServletRequest, Specification<E>> rejectRequest() {
     return r -> {
-      throw InvalidParameter.noParametersSpecified();
+      throw InvalidRequest.noParametersSpecified();
     };
   }
 

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Vulcan.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Vulcan.java
@@ -10,7 +10,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
@@ -20,7 +19,6 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
  * using AND semantics.
  */
 @Builder
-@Slf4j
 public class Vulcan<EntityT, JpaRepositoryT extends JpaSpecificationExecutor<EntityT>> {
 
   @NonNull private final JpaRepositoryT repository;
@@ -96,33 +94,11 @@ public class Vulcan<EntityT, JpaRepositoryT extends JpaSpecificationExecutor<Ent
     if (context.abortSearch()) {
       return resultsForAbortedSearch(context);
     }
-
-    log.info("specification {}", context.specification());
-    if (context.specification() == null) {
-      // TODO what to do when no request parameters were specified?
-      // TODO Select all
-      // TODO Select none
-      // TODO Configurable default specification?
-      // TODO Error?
-      return VulcanResult.<EntityT>builder()
-          .paging(
-              Paging.builder()
-                  .totalRecords(0)
-                  .totalPages(0)
-                  .firstPage(empty())
-                  .firstPageUrl(empty())
-                  .previousPage(empty())
-                  .previousPageUrl(empty())
-                  .thisPage(empty())
-                  .thisPageUrl(empty())
-                  .nextPage(empty())
-                  .nextPageUrl(empty())
-                  .lastPage(empty())
-                  .lastPageUrl(empty())
-                  .build())
-          .entities(Stream.empty())
-          .build();
-    }
+    // TODO what to do when no request parameters were specified?
+    // TODO Select all
+    // TODO Select none
+    // TODO Configurable default specification?
+    // TODO Error?
     if (context.countOnly()) {
       return resultsForCountOnly(context);
     }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/VulcanConfiguration.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/VulcanConfiguration.java
@@ -17,10 +17,19 @@ public class VulcanConfiguration<EntityT> {
   @NonNull PagingConfiguration paging;
   @Singular @NonNull List<Mapping<EntityT>> mappings;
   @NonNull Function<HttpServletRequest, Specification<EntityT>> defaultQuery;
+  @Singular List<Rule> rules;
 
   public static <E> VulcanConfigurationBuilder<E> forEntity(
       @SuppressWarnings("unused") Class<E> repo) {
     return VulcanConfiguration.builder();
+  }
+
+  /** Return the immutable list of rules. */
+  public List<Rule> rules() {
+    if (rules == null) {
+      return List.of();
+    }
+    return rules;
   }
 
   @Value

--- a/src/main/java/gov/va/api/lighthouse/vulcan/VulcanConfiguration.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/VulcanConfiguration.java
@@ -1,18 +1,22 @@
 package gov.va.api.lighthouse.vulcan;
 
 import java.util.List;
+import java.util.function.Function;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 
 @Value
 @Builder
 public class VulcanConfiguration<EntityT> {
   @NonNull PagingConfiguration paging;
   @Singular @NonNull List<Mapping<EntityT>> mappings;
+  @NonNull Function<HttpServletRequest, Specification<EntityT>> defaultQuery;
 
   public static <E> VulcanConfigurationBuilder<E> forEntity(
       @SuppressWarnings("unused") Class<E> repo) {

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/CsvListMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/CsvListMapping.java
@@ -2,7 +2,6 @@ package gov.va.api.lighthouse.vulcan.mappings;
 
 import static java.util.stream.Collectors.toSet;
 
-import gov.va.api.lighthouse.vulcan.SingleParameterMapping;
 import java.util.stream.Stream;
 import javax.persistence.criteria.CriteriaBuilder.In;
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/CsvListMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/CsvListMapping.java
@@ -1,7 +1,8 @@
-package gov.va.api.lighthouse.vulcan;
+package gov.va.api.lighthouse.vulcan.mappings;
 
 import static java.util.stream.Collectors.toSet;
 
+import gov.va.api.lighthouse.vulcan.SingleParameterMapping;
 import java.util.stream.Stream;
 import javax.persistence.criteria.CriteriaBuilder.In;
 import javax.servlet.http.HttpServletRequest;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/CsvListMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/CsvListMapping.java
@@ -1,9 +1,9 @@
 package gov.va.api.lighthouse.vulcan.mappings;
 
+import static gov.va.api.lighthouse.vulcan.Specifications.selectInList;
 import static java.util.stream.Collectors.toSet;
 
 import java.util.stream.Stream;
-import javax.persistence.criteria.CriteriaBuilder.In;
 import javax.servlet.http.HttpServletRequest;
 import lombok.Builder;
 import lombok.Value;
@@ -34,10 +34,6 @@ public class CsvListMapping<EntityT> implements SingleParameterMapping<EntityT> 
         Stream.of(request.getParameter(parameterName()).split("\\s*,\\s*"))
             .filter(StringUtils::isNotBlank)
             .collect(toSet());
-    return (root, criteriaQuery, criteriaBuilder) -> {
-      In<String> in = criteriaBuilder.in(root.get(fieldName()));
-      values.forEach(in::value);
-      return criteriaBuilder.or(in);
-    };
+    return selectInList(fieldName(), values);
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
@@ -3,7 +3,7 @@ package gov.va.api.lighthouse.vulcan.mappings;
 import static gov.va.api.lighthouse.vulcan.Predicates.andUsing;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import gov.va.api.lighthouse.vulcan.InvalidParameter;
+import gov.va.api.lighthouse.vulcan.InvalidRequest;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -61,7 +61,7 @@ public class DateMapping<EntityT, DateT> implements SingleParameterMapping<Entit
   public Specification<EntityT> specificationFor(HttpServletRequest request) {
     String[] dates = request.getParameterValues(parameterName());
     if (dates.length > 2) {
-      throw InvalidParameter.repeatedTooManyTimes(parameterName(), 2, dates.length);
+      throw InvalidRequest.repeatedTooManyTimes(parameterName(), 2, dates.length);
     }
     return (root, criteriaQuery, criteriaBuilder) -> {
       Path<DateT> field = root.get(fieldName());
@@ -188,7 +188,7 @@ public class DateMapping<EntityT, DateT> implements SingleParameterMapping<Entit
               criteriaBuilder.greaterThanOrEqualTo(field, approximation().expandLowerBound(date)),
               criteriaBuilder.lessThanOrEqualTo(field, approximation().expandUpperBound(date)));
         default:
-          throw new InvalidParameter("Unknown date search operator: " + date.operator());
+          throw new InvalidRequest("Unknown date search operator: " + date.operator());
       }
     }
   }
@@ -318,8 +318,8 @@ public class DateMapping<EntityT, DateT> implements SingleParameterMapping<Entit
       }
     }
 
-    private InvalidParameter invalidParameterValue() {
-      return InvalidParameter.badValue(
+    private InvalidRequest invalidParameterValue() {
+      return InvalidRequest.badParameter(
           parameterName,
           operatorAndDate,
           "Expected: [EQ|NE|GT|LT|GE|LE|SA|EB|AP]YYYY[-MM][-DD]['T'HH:MM:SS][Z|(+|-)HH:MM]");

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
@@ -1,8 +1,10 @@
-package gov.va.api.lighthouse.vulcan;
+package gov.va.api.lighthouse.vulcan.mappings;
 
 import static gov.va.api.lighthouse.vulcan.Predicates.andUsing;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
+import gov.va.api.lighthouse.vulcan.InvalidParameter;
+import gov.va.api.lighthouse.vulcan.SingleParameterMapping;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
@@ -4,7 +4,6 @@ import static gov.va.api.lighthouse.vulcan.Predicates.andUsing;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import gov.va.api.lighthouse.vulcan.InvalidParameter;
-import gov.va.api.lighthouse.vulcan.SingleParameterMapping;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/DateMapping.java
@@ -188,7 +188,7 @@ public class DateMapping<EntityT, DateT> implements SingleParameterMapping<Entit
               criteriaBuilder.greaterThanOrEqualTo(field, approximation().expandLowerBound(date)),
               criteriaBuilder.lessThanOrEqualTo(field, approximation().expandUpperBound(date)));
         default:
-          throw new IllegalArgumentException("Unknown search operator: " + date.operator());
+          throw new InvalidParameter("Unknown date search operator: " + date.operator());
       }
     }
   }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
  * Mapping builder for an entity. This provides easy to use methods to creating the different types
  * of common mappings.
  */
+@SuppressWarnings("unused")
 public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
 
   private final List<Mapping<EntityT>> mappings = new ArrayList<>();
@@ -84,6 +85,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
         StringMapping.<EntityT>builder().parameterName(parameterName).fieldName(fieldName).build());
   }
 
+  /** Create a token list mapping where field name is constant . */
   public Mappings<EntityT> token(
       String parameterName,
       String fieldName,
@@ -92,6 +94,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
     return token(parameterName, t -> fieldName, supportedToken, valueSelector);
   }
 
+  /** Create a token list mapping where parameter and field name are the same. */
   public Mappings<EntityT> token(
       String parameterAndFieldName,
       Predicate<TokenParameter> supportedToken,
@@ -99,6 +102,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
     return token(parameterAndFieldName, parameterAndFieldName, supportedToken, valueSelector);
   }
 
+  /** Create a token mapping where all aspects are configurable. */
   public Mappings<EntityT> token(
       String parameterName,
       Function<TokenParameter, String> fieldNameSelector,
@@ -113,6 +117,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
             .build());
   }
 
+  /** Create a token list mapping where field name is constant . */
   public Mappings<EntityT> tokenList(
       String parameterName,
       String fieldName,
@@ -121,6 +126,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
     return tokenList(parameterName, t -> fieldName, supportedToken, valueSelector);
   }
 
+  /** Create a token list mapping where parameter and field name are the same. */
   public Mappings<EntityT> tokenList(
       String parameterAndFieldName,
       Predicate<TokenParameter> supportedToken,
@@ -128,6 +134,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
     return tokenList(parameterAndFieldName, parameterAndFieldName, supportedToken, valueSelector);
   }
 
+  /** Create a token list mapping where all aspects are configurable. */
   public Mappings<EntityT> tokenList(
       String parameterName,
       Function<TokenParameter, String> fieldNameSelector,

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
@@ -3,8 +3,10 @@ package gov.va.api.lighthouse.vulcan.mappings;
 import gov.va.api.lighthouse.vulcan.Mapping;
 import gov.va.api.lighthouse.vulcan.mappings.DateMapping.PredicateFactory;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -80,6 +82,35 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
   public Mappings<EntityT> string(String parameterName, String fieldName) {
     return add(
         StringMapping.<EntityT>builder().parameterName(parameterName).fieldName(fieldName).build());
+  }
+
+  public Mappings<EntityT> token(
+      String parameterName,
+      String fieldName,
+      Predicate<TokenParameter> supportedToken,
+      Function<TokenParameter, Collection<String>> valueSelector) {
+    return token(parameterName, t -> fieldName, supportedToken, valueSelector);
+  }
+
+  public Mappings<EntityT> token(
+      String parameterAndFieldName,
+      Predicate<TokenParameter> supportedToken,
+      Function<TokenParameter, Collection<String>> valueSelector) {
+    return token(parameterAndFieldName, parameterAndFieldName, supportedToken, valueSelector);
+  }
+
+  public Mappings<EntityT> token(
+      String parameterName,
+      Function<TokenParameter, String> fieldNameSelector,
+      Predicate<TokenParameter> supportedToken,
+      Function<TokenParameter, Collection<String>> valueSelector) {
+    return add(
+        TokenMapping.<EntityT>builder()
+            .parameterName(parameterName)
+            .supportedToken(supportedToken)
+            .fieldNameSelector(fieldNameSelector)
+            .valueSelector(valueSelector)
+            .build());
   }
 
   /** Create a value mapping where request and field name are the same. */

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
@@ -113,6 +113,35 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
             .build());
   }
 
+  public Mappings<EntityT> tokenList(
+      String parameterName,
+      String fieldName,
+      Predicate<TokenParameter> supportedToken,
+      Function<TokenParameter, Collection<String>> valueSelector) {
+    return tokenList(parameterName, t -> fieldName, supportedToken, valueSelector);
+  }
+
+  public Mappings<EntityT> tokenList(
+      String parameterAndFieldName,
+      Predicate<TokenParameter> supportedToken,
+      Function<TokenParameter, Collection<String>> valueSelector) {
+    return tokenList(parameterAndFieldName, parameterAndFieldName, supportedToken, valueSelector);
+  }
+
+  public Mappings<EntityT> tokenList(
+      String parameterName,
+      Function<TokenParameter, String> fieldNameSelector,
+      Predicate<TokenParameter> supportedToken,
+      Function<TokenParameter, Collection<String>> valueSelector) {
+    return add(
+        TokenCsvListMapping.<EntityT>builder()
+            .parameterName(parameterName)
+            .supportedToken(supportedToken)
+            .fieldNameSelector(fieldNameSelector)
+            .valueSelector(valueSelector)
+            .build());
+  }
+
   /** Create a value mapping where request and field name are the same. */
   public Mappings<EntityT> value(String parameterAndFieldName, Function<String, ?> converter) {
     return value(parameterAndFieldName, parameterAndFieldName, converter);

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
@@ -1,6 +1,7 @@
-package gov.va.api.lighthouse.vulcan;
+package gov.va.api.lighthouse.vulcan.mappings;
 
-import gov.va.api.lighthouse.vulcan.DateMapping.PredicateFactory;
+import gov.va.api.lighthouse.vulcan.Mapping;
+import gov.va.api.lighthouse.vulcan.mappings.DateMapping.PredicateFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/SingleParameterMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/SingleParameterMapping.java
@@ -1,7 +1,8 @@
-package gov.va.api.lighthouse.vulcan;
+package gov.va.api.lighthouse.vulcan.mappings;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import gov.va.api.lighthouse.vulcan.Mapping;
 import javax.servlet.http.HttpServletRequest;
 
 /**

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
@@ -1,8 +1,9 @@
-package gov.va.api.lighthouse.vulcan;
+package gov.va.api.lighthouse.vulcan.mappings;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import gov.va.api.lighthouse.vulcan.Mapping;
 import java.util.Locale;
 import javax.servlet.http.HttpServletRequest;
 import lombok.Builder;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
@@ -61,9 +61,6 @@ public class StringMapping<EntityT> implements Mapping<EntityT> {
 
   private Specification<EntityT> clauseForExactMatch(HttpServletRequest request) {
     String value = request.getParameter(asExactParameterName());
-    if (isBlank(value)) {
-      return null;
-    }
     return (Specification<EntityT>)
         (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get(fieldName), value);
   }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenCsvListMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenCsvListMapping.java
@@ -14,13 +14,11 @@ import lombok.Builder;
 import lombok.ToString;
 import lombok.ToString.Include;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
 
 @Value
 @ToString(onlyExplicitlyIncluded = true)
 @Builder
-@Slf4j
 public class TokenCsvListMapping<EntityT> implements SingleParameterMapping<EntityT> {
 
   @Include String parameterName;
@@ -34,25 +32,19 @@ public class TokenCsvListMapping<EntityT> implements SingleParameterMapping<Enti
     List<TokenParameter> supportedTokens =
         Stream.of(request.getParameter(parameterName()).split("\\s*,\\s*"))
             .map(value -> TokenParameter.parse(parameterName(), value))
-            .filter(supportedToken)
+            .filter(supportedToken())
             .collect(toList());
 
-    log.info("Supported tokens {}", supportedTokens);
-
     if (supportedTokens.isEmpty()) {
-      log.info(
-          "{} no tokens is not supported: {}",
-          parameterName,
-          request.getParameter(parameterName()));
       throw CircuitBreaker.noResultsWillBeFound(
-          parameterName, request.getParameter(parameterName()), "No tokens are not supported");
+          parameterName(), request.getParameter(parameterName()), "No tokens are not supported");
     }
 
     return supportedTokens.stream()
         .map(
             token ->
                 Specifications.<EntityT>selectInList(
-                    fieldNameSelector.apply(token), valueSelector.apply(token)))
+                    fieldNameSelector().apply(token), valueSelector().apply(token)))
         .collect(Specifications.any());
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenCsvListMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenCsvListMapping.java
@@ -1,0 +1,58 @@
+package gov.va.api.lighthouse.vulcan.mappings;
+
+import static java.util.stream.Collectors.toList;
+
+import gov.va.api.lighthouse.vulcan.CircuitBreaker;
+import gov.va.api.lighthouse.vulcan.Specifications;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import javax.servlet.http.HttpServletRequest;
+import lombok.Builder;
+import lombok.ToString;
+import lombok.ToString.Include;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.domain.Specification;
+
+@Value
+@ToString(onlyExplicitlyIncluded = true)
+@Builder
+@Slf4j
+public class TokenCsvListMapping<EntityT> implements SingleParameterMapping<EntityT> {
+
+  @Include String parameterName;
+  Predicate<TokenParameter> supportedToken;
+  Function<TokenParameter, String> fieldNameSelector;
+  Function<TokenParameter, Collection<String>> valueSelector;
+
+  @Override
+  public Specification<EntityT> specificationFor(HttpServletRequest request) {
+
+    List<TokenParameter> supportedTokens =
+        Stream.of(request.getParameter(parameterName()).split("\\s*,\\s*"))
+            .map(value -> TokenParameter.parse(parameterName(), value))
+            .filter(supportedToken)
+            .collect(toList());
+
+    log.info("Supported tokens {}", supportedTokens);
+
+    if (supportedTokens.isEmpty()) {
+      log.info(
+          "{} no tokens is not supported: {}",
+          parameterName,
+          request.getParameter(parameterName()));
+      throw CircuitBreaker.noResultsWillBeFound(
+          parameterName, request.getParameter(parameterName()), "No tokens are not supported");
+    }
+
+    return supportedTokens.stream()
+        .map(
+            token ->
+                Specifications.<EntityT>selectInList(
+                    fieldNameSelector.apply(token), valueSelector.apply(token)))
+        .collect(Specifications.any());
+  }
+}

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
@@ -29,11 +29,11 @@ public class TokenMapping<EntityT> implements SingleParameterMapping<EntityT> {
   public Specification<EntityT> specificationFor(HttpServletRequest request) {
     TokenParameter token =
         TokenParameter.parse(parameterName(), request.getParameter(parameterName()));
-    if (!supportedToken.test(token)) {
-      log.info("{} token is not supported: {}", parameterName, token);
+    if (!supportedToken().test(token)) {
+      log.info("{} token is not supported: {}", parameterName(), token);
       throw CircuitBreaker.noResultsWillBeFound(
-          parameterName, request.getParameter(parameterName()), "Token is not supported");
+          parameterName(), request.getParameter(parameterName()), "Token is not supported");
     }
-    return selectInList(fieldNameSelector.apply(token), valueSelector.apply(token));
+    return selectInList(fieldNameSelector().apply(token), valueSelector().apply(token));
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
@@ -11,13 +11,11 @@ import lombok.Builder;
 import lombok.ToString;
 import lombok.ToString.Include;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
 
 @Value
 @ToString(onlyExplicitlyIncluded = true)
 @Builder
-@Slf4j
 public class TokenMapping<EntityT> implements SingleParameterMapping<EntityT> {
 
   @Include String parameterName;
@@ -30,7 +28,6 @@ public class TokenMapping<EntityT> implements SingleParameterMapping<EntityT> {
     TokenParameter token =
         TokenParameter.parse(parameterName(), request.getParameter(parameterName()));
     if (!supportedToken().test(token)) {
-      log.info("{} token is not supported: {}", parameterName(), token);
       throw CircuitBreaker.noResultsWillBeFound(
           parameterName(), request.getParameter(parameterName()), "Token is not supported");
     }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
@@ -1,0 +1,47 @@
+package gov.va.api.lighthouse.vulcan.mappings;
+
+import gov.va.api.lighthouse.vulcan.CircuitBreaker;
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import javax.persistence.criteria.CriteriaBuilder.In;
+import javax.servlet.http.HttpServletRequest;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.domain.Specification;
+
+@Value
+@Builder
+@Slf4j
+public class TokenMapping<EntityT> implements SingleParameterMapping<EntityT> {
+
+  String parameterName;
+  Predicate<TokenParameter> supportedToken;
+  Function<TokenParameter, String> fieldNameSelector;
+  Function<TokenParameter, Collection<String>> valueSelector;
+
+  @Override
+  public Specification<EntityT> specificationFor(HttpServletRequest request) {
+    TokenParameter token =
+        TokenParameter.parse(parameterName(), request.getParameter(parameterName()));
+    if (!supportedToken.test(token)) {
+      log.info("{} token is not supported: {}", parameterName, token);
+      throw CircuitBreaker.noResultsWillBeFound(
+          parameterName, request.getParameter(parameterName()), "Token is not supported");
+    }
+    String fieldName = fieldNameSelector.apply(token);
+    Collection<String> values = valueSelector().apply(token);
+    if (values.size() == 1) {
+      log.info("{} only one value {}", parameterName, values);
+      return (root, criteriaQuery, criteriaBuilder) ->
+          criteriaBuilder.equal(root.get(fieldName), values.stream().findFirst().orElseThrow());
+    }
+    log.info("{} multiple values {}", parameterName, values);
+    return (root, criteriaQuery, criteriaBuilder) -> {
+      In<String> in = criteriaBuilder.in(root.get(fieldName));
+      values.forEach(in::value);
+      return criteriaBuilder.or(in);
+    };
+  }
+}

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenMapping.java
@@ -1,22 +1,26 @@
 package gov.va.api.lighthouse.vulcan.mappings;
 
+import static gov.va.api.lighthouse.vulcan.Specifications.selectInList;
+
 import gov.va.api.lighthouse.vulcan.CircuitBreaker;
 import java.util.Collection;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import javax.persistence.criteria.CriteriaBuilder.In;
 import javax.servlet.http.HttpServletRequest;
 import lombok.Builder;
+import lombok.ToString;
+import lombok.ToString.Include;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
 
 @Value
+@ToString(onlyExplicitlyIncluded = true)
 @Builder
 @Slf4j
 public class TokenMapping<EntityT> implements SingleParameterMapping<EntityT> {
 
-  String parameterName;
+  @Include String parameterName;
   Predicate<TokenParameter> supportedToken;
   Function<TokenParameter, String> fieldNameSelector;
   Function<TokenParameter, Collection<String>> valueSelector;
@@ -30,18 +34,6 @@ public class TokenMapping<EntityT> implements SingleParameterMapping<EntityT> {
       throw CircuitBreaker.noResultsWillBeFound(
           parameterName, request.getParameter(parameterName()), "Token is not supported");
     }
-    String fieldName = fieldNameSelector.apply(token);
-    Collection<String> values = valueSelector().apply(token);
-    if (values.size() == 1) {
-      log.info("{} only one value {}", parameterName, values);
-      return (root, criteriaQuery, criteriaBuilder) ->
-          criteriaBuilder.equal(root.get(fieldName), values.stream().findFirst().orElseThrow());
-    }
-    log.info("{} multiple values {}", parameterName, values);
-    return (root, criteriaQuery, criteriaBuilder) -> {
-      In<String> in = criteriaBuilder.in(root.get(fieldName));
-      values.forEach(in::value);
-      return criteriaBuilder.or(in);
-    };
+    return selectInList(fieldNameSelector.apply(token), valueSelector.apply(token));
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
@@ -84,7 +84,9 @@ public class TokenParameter {
     return supportedCode.equals(code);
   }
 
-  public <E extends Enum<E>> boolean hasSupportedCode(E... supportedCodes) {
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  public final <E extends Enum<E>> boolean hasSupportedCode(E... supportedCodes) {
     return Arrays.stream(supportedCodes).anyMatch(this::hasSupportedCode);
   }
 
@@ -105,11 +107,13 @@ public class TokenParameter {
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final <E extends Enum<E>> boolean isCodeExplicitAndUnsupported(E... supportedCodes) {
     return hasExplicitCode() && !hasSupportedCode(supportedCodes);
   }
 
   @SafeVarargs
+  @SuppressWarnings("varargs")
   public final <E extends Enum<E>> boolean isCodeExplicitlySetAndOneOf(E... supportedCodes) {
     return hasExplicitCode() && hasSupportedCode(supportedCodes);
   }
@@ -142,30 +146,18 @@ public class TokenParameter {
   public static class Behavior<T> {
     @NonNull TokenParameter token;
 
-    @Builder.Default
-    Function<String, T> onAnySystemAndExplicitCode =
-        s -> throwNotConfigured("onAnySystemAndExplicitCode");
+    Function<String, T> onAnySystemAndExplicitCode;
 
-    @Builder.Default
-    Function<String, T> onExplicitSystemAndAnyCode =
-        s -> throwNotConfigured("onExplicitSystemAndAnyCode");
+    Function<String, T> onExplicitSystemAndAnyCode;
 
-    @Builder.Default
-    BiFunction<String, String, T> onExplicitSystemAndExplicitCode =
-        (s, c) -> throwNotConfigured("onNoSystemAndExplicitCode");
+    BiFunction<String, String, T> onExplicitSystemAndExplicitCode;
 
-    @Builder.Default
-    Function<String, T> onNoSystemAndExplicitCode =
-        s -> throwNotConfigured("onNoSystemAndExplicitCode");
-
-    private static <T> T throwNotConfigured(String state) {
-      throw new IllegalStateException("Behavior not configured for state: " + state);
-    }
+    Function<String, T> onNoSystemAndExplicitCode;
 
     /** Check if behavior is specified before executing it. */
     public <T1> T1 check(T1 n) {
       if (n == null) {
-        throw new IllegalStateException("no handler specified for " + token.mode);
+        throw new IllegalStateException("no handler specified for " + token().mode);
       }
       return n;
     }
@@ -174,17 +166,17 @@ public class TokenParameter {
     @SuppressWarnings("UnnecessaryDefault")
     @SneakyThrows
     public T execute() {
-      switch (token.mode) {
+      switch (token().mode) {
         case ANY_SYSTEM_EXPLICIT_CODE:
-          return check(onAnySystemAndExplicitCode).apply(token.code);
+          return check(onAnySystemAndExplicitCode()).apply(token().code);
         case EXPLICIT_SYSTEM_ANY_CODE:
-          return check(onExplicitSystemAndAnyCode).apply(token.system);
+          return check(onExplicitSystemAndAnyCode()).apply(token().system);
         case EXPLICIT_SYSTEM_EXPLICIT_CODE:
-          return check(onExplicitSystemAndExplicitCode).apply(token.system, token.code);
+          return check(onExplicitSystemAndExplicitCode()).apply(token().system, token().code);
         case NO_SYSTEM_EXPLICIT_CODE:
-          return check(onNoSystemAndExplicitCode).apply(token.code);
+          return check(onNoSystemAndExplicitCode()).apply(token().code);
         default:
-          throw new IllegalStateException("TokenParameter in unsupported mode : " + token.mode);
+          throw new IllegalStateException("TokenParameter in unsupported mode : " + token().mode);
       }
     }
   }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
@@ -2,7 +2,7 @@ package gov.va.api.lighthouse.vulcan.mappings;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-import gov.va.api.lighthouse.vulcan.InvalidParameter;
+import gov.va.api.lighthouse.vulcan.InvalidRequest;
 import java.util.Arrays;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -24,7 +24,7 @@ public class TokenParameter {
   @SneakyThrows
   public static TokenParameter parse(String parameterName, String value) {
     if (isBlank(value) || value.equals("|")) {
-      throw InvalidParameter.badValue(
+      throw InvalidRequest.badParameter(
           parameterName, value, "Expected value, system|value, |value, or system|");
     }
     if (value.startsWith("|")) {

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
@@ -124,13 +124,25 @@ public class TokenParameter {
   public static class Behavior<T> {
     @NonNull TokenParameter token;
 
-    Function<String, T> onAnySystemAndExplicitCode;
+    @Builder.Default
+    Function<String, T> onAnySystemAndExplicitCode =
+        s -> throwNotConfigured("onAnySystemAndExplicitCode");
 
-    Function<String, T> onExplicitSystemAndAnyCode;
+    @Builder.Default
+    Function<String, T> onExplicitSystemAndAnyCode =
+        s -> throwNotConfigured("onExplicitSystemAndAnyCode");
 
-    BiFunction<String, String, T> onExplicitSystemAndExplicitCode;
+    @Builder.Default
+    BiFunction<String, String, T> onExplicitSystemAndExplicitCode =
+        (s, c) -> throwNotConfigured("onNoSystemAndExplicitCode");
 
-    Function<String, T> onNoSystemAndExplicitCode;
+    @Builder.Default
+    Function<String, T> onNoSystemAndExplicitCode =
+        s -> throwNotConfigured("onNoSystemAndExplicitCode");
+
+    private static <T> T throwNotConfigured(String state) {
+      throw new IllegalStateException("Behavior not configured for state: " + state);
+    }
 
     /** Check if behavior is specified before executing it. */
     public <T1> T1 check(T1 n) {

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
@@ -1,0 +1,181 @@
+package gov.va.api.lighthouse.vulcan.mappings;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import gov.va.api.lighthouse.vulcan.InvalidParameter;
+import java.util.Arrays;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.Value;
+
+@Value
+@Builder
+public class TokenParameter {
+  String system;
+
+  String code;
+
+  @NonNull Mode mode;
+
+  /** Create a TokenParameter from a token search parameter. */
+  @SneakyThrows
+  public static TokenParameter parse(String parameterName, String value) {
+    if (isBlank(value) || value.equals("|")) {
+      throw InvalidParameter.badValue(
+          parameterName, value, "Expected value, system|value, |value, or system|");
+    }
+    if (value.startsWith("|")) {
+      return TokenParameter.builder()
+          .code(value.substring(1))
+          .mode(Mode.NO_SYSTEM_EXPLICIT_CODE)
+          .build();
+    }
+    if (value.endsWith("|")) {
+      return TokenParameter.builder()
+          .system(value.substring(0, value.length() - 1))
+          .mode(Mode.EXPLICIT_SYSTEM_ANY_CODE)
+          .build();
+    }
+    if (value.contains("|")) {
+      return TokenParameter.builder()
+          .system(value.substring(0, value.indexOf("|")))
+          .code(value.substring((value.indexOf("|") + 1)))
+          .mode(Mode.EXPLICIT_SYSTEM_EXPLICIT_CODE)
+          .build();
+    }
+    return TokenParameter.builder().code(value).mode(Mode.ANY_SYSTEM_EXPLICIT_CODE).build();
+  }
+
+  public BehaviorStemCell behavior() {
+    return new BehaviorStemCell();
+  }
+
+  public boolean hasAnyCode() {
+    return mode == Mode.EXPLICIT_SYSTEM_ANY_CODE;
+  }
+
+  public boolean hasAnySystem() {
+    return mode == Mode.ANY_SYSTEM_EXPLICIT_CODE;
+  }
+
+  /** Determines if the token has an explicit code. */
+  public boolean hasExplicitCode() {
+    return mode == Mode.EXPLICIT_SYSTEM_EXPLICIT_CODE
+        || mode == Mode.NO_SYSTEM_EXPLICIT_CODE
+        || mode == Mode.ANY_SYSTEM_EXPLICIT_CODE;
+  }
+
+  public boolean hasExplicitSystem() {
+    return mode == Mode.EXPLICIT_SYSTEM_ANY_CODE || mode == Mode.EXPLICIT_SYSTEM_EXPLICIT_CODE;
+  }
+
+  public boolean hasExplicitlyNoSystem() {
+    return mode == Mode.NO_SYSTEM_EXPLICIT_CODE;
+  }
+
+  public boolean hasSupportedCode(String supportedCode) {
+    return supportedCode.equals(code);
+  }
+
+  public boolean hasSupportedCode(String... codes) {
+    return Arrays.stream(codes).anyMatch(this::hasSupportedCode);
+  }
+
+  public boolean hasSupportedSystem(String supportedSystem) {
+    return supportedSystem.equals(system);
+  }
+
+  public boolean hasSupportedSystem(String... systems) {
+    return Arrays.stream(systems).anyMatch(this::hasSupportedSystem);
+  }
+
+  public boolean isCodeExplicitAndUnsupported(String... codes) {
+    return hasExplicitCode() && !hasSupportedCode(codes);
+  }
+
+  public boolean isCodeExplicitlySetAndOneOf(String... codes) {
+    return hasExplicitCode() && hasSupportedCode(codes);
+  }
+
+  public boolean isSystemExplicitAndUnsupported(String... systems) {
+    return hasExplicitSystem() && !hasSupportedSystem(systems);
+  }
+
+  public boolean isSystemExplicitlySetAndOneOf(String... systems) {
+    return hasExplicitSystem() && hasSupportedSystem(systems);
+  }
+
+  public enum Mode {
+    /** e.g. cool */
+    ANY_SYSTEM_EXPLICIT_CODE,
+    /** e.g. http://fonzy.com| */
+    EXPLICIT_SYSTEM_ANY_CODE,
+    /** e.g. http://fonzy.com|cool */
+    EXPLICIT_SYSTEM_EXPLICIT_CODE,
+    /** e.g. |cool */
+    NO_SYSTEM_EXPLICIT_CODE
+  }
+
+  @Value
+  @Builder
+  public static class Behavior<T> {
+    @NonNull TokenParameter token;
+
+    Function<String, T> onAnySystemAndExplicitCode;
+
+    Function<String, T> onExplicitSystemAndAnyCode;
+
+    BiFunction<String, String, T> onExplicitSystemAndExplicitCode;
+
+    Function<String, T> onNoSystemAndExplicitCode;
+
+    /** Check if behavior is specified before executing it. */
+    public <T1> T1 check(T1 n) {
+      if (n == null) {
+        throw new IllegalStateException("no handler specified for " + token.mode);
+      }
+      return n;
+    }
+
+    /** Execute correct behavior based on the mode of the token. */
+    @SuppressWarnings("UnnecessaryDefault")
+    @SneakyThrows
+    public T execute() {
+      switch (token.mode) {
+        case ANY_SYSTEM_EXPLICIT_CODE:
+          return check(onAnySystemAndExplicitCode).apply(token.code);
+        case EXPLICIT_SYSTEM_ANY_CODE:
+          return check(onExplicitSystemAndAnyCode).apply(token.system);
+        case EXPLICIT_SYSTEM_EXPLICIT_CODE:
+          return check(onExplicitSystemAndExplicitCode).apply(token.system, token.code);
+        case NO_SYSTEM_EXPLICIT_CODE:
+          return check(onNoSystemAndExplicitCode).apply(token.code);
+        default:
+          throw new IllegalStateException("TokenParameter in unsupported mode : " + token.mode);
+      }
+    }
+  }
+
+  public final class BehaviorStemCell {
+    public <T> Behavior.BehaviorBuilder<T> onAnySystemAndExplicitCode(Function<String, T> f) {
+      return Behavior.<T>builder().token(TokenParameter.this).onAnySystemAndExplicitCode(f);
+    }
+
+    public <T> Behavior.BehaviorBuilder<T> onExplicitSystemAndAnyCode(Function<String, T> f) {
+      return Behavior.<T>builder().token(TokenParameter.this).onExplicitSystemAndAnyCode(f);
+    }
+
+    public <T> Behavior.BehaviorBuilder<T> onExplicitSystemAndExplicitCode(
+        BiFunction<String, String, T> f) {
+      return Behavior.<T>builder().token(TokenParameter.this).onExplicitSystemAndExplicitCode(f);
+    }
+
+    @SuppressWarnings("unused")
+    public <T> Behavior.BehaviorBuilder<T> onNoSystemAndExplicitCode(Function<String, T> f) {
+      return Behavior.<T>builder().token(TokenParameter.this).onNoSystemAndExplicitCode(f);
+    }
+  }
+}

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameter.java
@@ -76,36 +76,54 @@ public class TokenParameter {
     return mode == Mode.NO_SYSTEM_EXPLICIT_CODE;
   }
 
+  public <E extends Enum<E>> boolean hasSupportedCode(E supportedCode) {
+    return supportedCode.toString().equals(code);
+  }
+
   public boolean hasSupportedCode(String supportedCode) {
     return supportedCode.equals(code);
   }
 
-  public boolean hasSupportedCode(String... codes) {
-    return Arrays.stream(codes).anyMatch(this::hasSupportedCode);
+  public <E extends Enum<E>> boolean hasSupportedCode(E... supportedCodes) {
+    return Arrays.stream(supportedCodes).anyMatch(this::hasSupportedCode);
+  }
+
+  public boolean hasSupportedCode(String... supportedCodes) {
+    return Arrays.stream(supportedCodes).anyMatch(this::hasSupportedCode);
   }
 
   public boolean hasSupportedSystem(String supportedSystem) {
     return supportedSystem.equals(system);
   }
 
-  public boolean hasSupportedSystem(String... systems) {
-    return Arrays.stream(systems).anyMatch(this::hasSupportedSystem);
+  public boolean hasSupportedSystem(String... supportedSystems) {
+    return Arrays.stream(supportedSystems).anyMatch(this::hasSupportedSystem);
   }
 
-  public boolean isCodeExplicitAndUnsupported(String... codes) {
-    return hasExplicitCode() && !hasSupportedCode(codes);
+  public boolean isCodeExplicitAndUnsupported(String... supportedCodes) {
+    return hasExplicitCode() && !hasSupportedCode(supportedCodes);
   }
 
-  public boolean isCodeExplicitlySetAndOneOf(String... codes) {
-    return hasExplicitCode() && hasSupportedCode(codes);
+  @SafeVarargs
+  public final <E extends Enum<E>> boolean isCodeExplicitAndUnsupported(E... supportedCodes) {
+    return hasExplicitCode() && !hasSupportedCode(supportedCodes);
   }
 
-  public boolean isSystemExplicitAndUnsupported(String... systems) {
-    return hasExplicitSystem() && !hasSupportedSystem(systems);
+  @SafeVarargs
+  public final <E extends Enum<E>> boolean isCodeExplicitlySetAndOneOf(E... supportedCodes) {
+    return hasExplicitCode() && hasSupportedCode(supportedCodes);
   }
 
-  public boolean isSystemExplicitlySetAndOneOf(String... systems) {
-    return hasExplicitSystem() && hasSupportedSystem(systems);
+  public boolean isCodeExplicitlySetAndOneOf(String... supportedCodes) {
+    return hasExplicitCode() && hasSupportedCode(supportedCodes);
+  }
+
+  public boolean isSystemExplicitAndUnsupported(String... supportedSystems) {
+    return hasExplicitSystem() && !hasSupportedSystem(supportedSystems);
+  }
+
+  public boolean isSystemExplicitlySetAndOneOf(String... supportedSystems) {
+    return hasExplicitSystem() && hasSupportedSystem(supportedSystems);
   }
 
   public enum Mode {

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ValueMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ValueMapping.java
@@ -1,5 +1,6 @@
-package gov.va.api.lighthouse.vulcan;
+package gov.va.api.lighthouse.vulcan.mappings;
 
+import gov.va.api.lighthouse.vulcan.SingleParameterMapping;
 import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
 import lombok.Builder;

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ValueMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ValueMapping.java
@@ -1,11 +1,9 @@
 package gov.va.api.lighthouse.vulcan.mappings;
 
-import gov.va.api.lighthouse.vulcan.SingleParameterMapping;
 import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
 import lombok.Builder;
 import lombok.Value;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.jpa.domain.Specification;
 
 /**
@@ -14,7 +12,6 @@ import org.springframework.data.jpa.domain.Specification;
  */
 @Value
 @Builder
-@Slf4j
 public class ValueMapping<EntityT> implements SingleParameterMapping<EntityT> {
 
   String parameterName;
@@ -26,7 +23,6 @@ public class ValueMapping<EntityT> implements SingleParameterMapping<EntityT> {
   @Override
   public Specification<EntityT> specificationFor(HttpServletRequest request) {
     var value = converter.apply(request.getParameter(parameterName()));
-    log.info("lt {}", value);
     return (root, criteriaQuery, criteriaBuilder) ->
         criteriaBuilder.equal(root.get(fieldName()), value);
   }

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RequestContextTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RequestContextTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration.PagingConfiguration;
 import gov.va.api.lighthouse.vulcan.fugazi.FugaziEntity;
+import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
@@ -1,0 +1,114 @@
+package gov.va.api.lighthouse.vulcan;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+class RulesTest {
+
+  @Test
+  void atLeastOneParameterOf() {
+    Rules.atLeastOneParameterOf("foo", "bar").check(requestWithParameters("foo"));
+    Rules.atLeastOneParameterOf("foo", "bar").check(requestWithParameters("bar"));
+    Rules.atLeastOneParameterOf("foo", "bar").check(requestWithParameters("foo", "bar"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () -> Rules.atLeastOneParameterOf("foo", "bar").check(requestWithParameters("nope")));
+  }
+
+  @Test
+  void forbiddenParameters() {
+    Rules.forbiddenParameters("foo", "bar").check(requestWithParameters("whatever"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () -> Rules.forbiddenParameters("foo", "bar").check(requestWithParameters("foo")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () -> Rules.forbiddenParameters("foo", "bar").check(requestWithParameters("bar")));
+  }
+
+  @Test
+  void ifParameterThenAlsoAtLeastOneParameterOf() {
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("bar", "ack")
+        .check(requestWithParameters("whatever"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("bar", "ack")
+        .check(requestWithParameters("foo", "bar"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("bar", "ack")
+        .check(requestWithParameters("foo", "bar", "ack"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("bar", "ack")
+        .check(requestWithParameters("foo", "ack", "whatever"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("bar", "ack")
+        .check(requestWithParameters("foo", "ack"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenAlsoAtLeastOneParameterOf("bar", "ack")
+                    .check(requestWithParameters("foo", "whatever")));
+  }
+
+  @Test
+  void ifParameterThenForbidParameters() {
+    Rules.ifParameter("foo")
+        .thenForbidParameters("bar", "ack")
+        .check(requestWithParameters("whatever"));
+    Rules.ifParameter("foo")
+        .thenForbidParameters("bar", "ack")
+        .check(requestWithParameters("foo", "whatever"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenForbidParameters("bar", "ack")
+                    .check(requestWithParameters("foo", "bar")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenForbidParameters("bar", "ack")
+                    .check(requestWithParameters("foo", "ack")));
+  }
+
+  @Test
+  void parametersAlwaysSpecifiedTogether() {
+    Rules.parametersAlwaysSpecifiedTogether("foo", "bar").check(requestWithParameters("whatever"));
+    Rules.parametersAlwaysSpecifiedTogether("foo", "bar")
+        .check(requestWithParameters("foo", "bar"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersAlwaysSpecifiedTogether("foo", "bar")
+                    .check(requestWithParameters("foo")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersAlwaysSpecifiedTogether("foo", "bar")
+                    .check(requestWithParameters("bar")));
+  }
+
+  @Test
+  void parametersNeverSpecifiedTogether() {
+    Rules.parametersNeverSpecifiedTogether("foo", "bar").check(requestWithParameters("whatever"));
+    Rules.parametersNeverSpecifiedTogether("foo", "bar").check(requestWithParameters("foo"));
+    Rules.parametersNeverSpecifiedTogether("foo", "bar").check(requestWithParameters("bar"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersNeverSpecifiedTogether("foo", "bar")
+                    .check(requestWithParameters("foo", "bar")));
+  }
+
+  private MockHttpServletRequest requestWithParameters(String... parameters) {
+    MockHttpServletRequest req = new MockHttpServletRequest();
+    for (String p : parameters) {
+      req.addParameter(p, "value of " + p);
+    }
+    return req;
+  }
+}

--- a/src/test/java/gov/va/api/lighthouse/vulcan/SpecificationsTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/SpecificationsTest.java
@@ -1,0 +1,75 @@
+package gov.va.api.lighthouse.vulcan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import gov.va.api.lighthouse.vulcan.fugazi.FugaziEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+class SpecificationsTest {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void collectAll() {
+    assertThat(Stream.<Specification<FugaziEntity>>of().collect(Specifications.all())).isNull();
+
+    List<Specification<FugaziEntity>> specs = new ArrayList<>(3);
+    specs.add(mock(Specification.class));
+    specs.add(mock(Specification.class));
+    specs.add(mock(Specification.class));
+    List<Specification<FugaziEntity>> anded = new ArrayList<>();
+    specs.forEach(
+        m -> {
+          when(m.and(any(Specification.class)))
+              .thenAnswer(
+                  i -> {
+                    anded.add(i.getArgument(0));
+                    return i.getMock();
+                  });
+        });
+
+    Specification<FugaziEntity> all = specs.stream().collect(Specifications.all());
+    // all will be one of the specs passed in
+    assertThat(specs.remove(all)).isTrue();
+    // the other two specs will have been anded with it
+    assertThat(anded).containsExactlyInAnyOrderElementsOf(specs);
+    verify(all).and(specs.get(1));
+    verify(all).and(specs.get(0));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void collectAny() {
+    assertThat(Stream.<Specification<FugaziEntity>>of().collect(Specifications.any())).isNull();
+
+    List<Specification<FugaziEntity>> specs = new ArrayList<>(3);
+    specs.add(mock(Specification.class));
+    specs.add(mock(Specification.class));
+    specs.add(mock(Specification.class));
+    List<Specification<FugaziEntity>> ored = new ArrayList<>();
+    specs.forEach(
+        m -> {
+          when(m.or(any(Specification.class)))
+              .thenAnswer(
+                  i -> {
+                    ored.add(i.getArgument(0));
+                    return i.getMock();
+                  });
+        });
+
+    Specification<FugaziEntity> all = specs.stream().collect(Specifications.any());
+    // all will be one of the specs passed in
+    assertThat(specs.remove(all)).isTrue();
+    // the other two specs will have been anded with it
+    assertThat(ored).containsExactlyInAnyOrderElementsOf(specs);
+    verify(all).or(specs.get(1));
+    verify(all).or(specs.get(0));
+  }
+}

--- a/src/test/java/gov/va/api/lighthouse/vulcan/VulcanTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/VulcanTest.java
@@ -16,6 +16,7 @@ import gov.va.api.lighthouse.vulcan.fugazi.FugaziDto;
 import gov.va.api.lighthouse.vulcan.fugazi.FugaziDto.Food;
 import gov.va.api.lighthouse.vulcan.fugazi.FugaziEntity;
 import gov.va.api.lighthouse.vulcan.fugazi.FugaziRepository;
+import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/gov/va/api/lighthouse/vulcan/VulcanTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/VulcanTest.java
@@ -172,7 +172,7 @@ class VulcanTest {
             .build();
     var request = new MockHttpServletRequest();
     request.setRequestURI("/fugazi");
-    assertThatExceptionOfType(InvalidParameter.class).isThrownBy(() -> vulcan.forge(request));
+    assertThatExceptionOfType(InvalidRequest.class).isThrownBy(() -> vulcan.forge(request));
   }
 
   @ParameterizedTest

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/ExampleUsage.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/ExampleUsage.java
@@ -1,5 +1,10 @@
 package gov.va.api.lighthouse.vulcan.fugazi;
 
+import static gov.va.api.lighthouse.vulcan.Rules.atLeastOneParameterOf;
+import static gov.va.api.lighthouse.vulcan.Rules.forbiddenParameters;
+import static gov.va.api.lighthouse.vulcan.Rules.ifParameter;
+import static gov.va.api.lighthouse.vulcan.Rules.parametersAlwaysSpecifiedTogether;
+import static gov.va.api.lighthouse.vulcan.Rules.parametersNeverSpecifiedTogether;
 import static gov.va.api.lighthouse.vulcan.Vulcan.rejectRequest;
 import static gov.va.api.lighthouse.vulcan.Vulcan.useUrl;
 import static java.util.stream.Collectors.toList;
@@ -47,6 +52,12 @@ public class ExampleUsage {
                 .dateAsInstant("when", "date")
                 .get())
         .defaultQuery(rejectRequest())
+        .rule(atLeastOneParameterOf("patient", "_id"))
+        .rule(parametersNeverSpecifiedTogether("patient", "_id"))
+        .rule(forbiddenParameters("client-key"))
+        .rule(ifParameter("patient").thenAlsoAtLeastOneParameterOf("category", "code"))
+        .rule(ifParameter("category").thenForbidParameters("code"))
+        .rule(parametersAlwaysSpecifiedTogether("latitude", "longitude"))
         .build();
   }
 

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/ExampleUsage.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/ExampleUsage.java
@@ -1,5 +1,6 @@
 package gov.va.api.lighthouse.vulcan.fugazi;
 
+import static gov.va.api.lighthouse.vulcan.Vulcan.rejectRequest;
 import static gov.va.api.lighthouse.vulcan.Vulcan.useUrl;
 import static java.util.stream.Collectors.toList;
 
@@ -45,6 +46,7 @@ public class ExampleUsage {
                 .value("millis", v -> Instant.parse(v).toEpochMilli())
                 .dateAsInstant("when", "date")
                 .get())
+        .defaultQuery(rejectRequest())
         .build();
   }
 

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/ExampleUsage.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/ExampleUsage.java
@@ -5,10 +5,10 @@ import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.lighthouse.vulcan.Mappings;
 import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration.PagingConfiguration;
+import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import java.time.Instant;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
@@ -69,6 +69,7 @@ public class FugaziController {
                 .token("foodtoken", "food", this::foodIsSupported, this::foodValues)
                 .tokenList("foodtokencsv", "food", this::foodIsSupported, this::foodValues)
                 .get())
+        .defaultQuery(Vulcan.returnNothing())
         .build();
   }
 

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
@@ -59,16 +59,20 @@ public class FugaziController {
             Mappings.forEntity(FugaziEntity.class)
                 .string("name")
                 .string("xname", "name")
+                .value("namevalue", "name")
                 .csvList("food")
                 .csvList("xfood", "food")
+                .value("namevalue", "name")
                 .value("millis", v -> Instant.parse(v).toEpochMilli())
                 .value("xmillis", "millis", v -> Instant.parse(v).toEpochMilli())
                 .dateAsInstant("xdate", "date")
                 .token("foodtoken", "food", this::foodIsSupported, this::foodValues)
+                .tokenList("foodtokencsv", "food", this::foodIsSupported, this::foodValues)
                 .get())
         .build();
   }
 
+  @SuppressWarnings("RedundantIfStatement")
   private boolean foodIsSupported(TokenParameter token) {
     if (token.isSystemExplicitAndUnsupported("http://food")
         || token.isCodeExplicitAndUnsupported(Food.values())

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
@@ -2,15 +2,21 @@ package gov.va.api.lighthouse.vulcan.fugazi;
 
 import static gov.va.api.lighthouse.vulcan.Vulcan.useUrl;
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
 import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration.PagingConfiguration;
+import gov.va.api.lighthouse.vulcan.fugazi.FugaziDto.Food;
 import gov.va.api.lighthouse.vulcan.mappings.Mappings;
+import gov.va.api.lighthouse.vulcan.mappings.TokenParameter;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -58,14 +64,46 @@ public class FugaziController {
                 .value("millis", v -> Instant.parse(v).toEpochMilli())
                 .value("xmillis", "millis", v -> Instant.parse(v).toEpochMilli())
                 .dateAsInstant("xdate", "date")
+                .token("foodtoken", "food", this::foodIsSupported, this::foodValues)
                 .get())
         .build();
+  }
+
+  private boolean foodIsSupported(TokenParameter token) {
+    if (token.isSystemExplicitAndUnsupported("http://food")
+        || token.isCodeExplicitAndUnsupported(Food.values())
+        || token.hasExplicitlyNoSystem()) {
+      return false;
+    }
+    return true;
+  }
+
+  private Collection<String> foodValues(TokenParameter token) {
+    return token
+        .behavior()
+        .onExplicitSystemAndExplicitCode((s, c) -> foodsForStrings(c))
+        .onAnySystemAndExplicitCode(this::foodsForStrings)
+        .onNoSystemAndExplicitCode(this::foodsForStrings)
+        .onExplicitSystemAndAnyCode(s -> Set.of(Food.values()))
+        .build()
+        .execute()
+        .stream()
+        .filter(Objects::nonNull)
+        .map(Food::toString)
+        .collect(toList());
+  }
+
+  Set<Food> foodsForStrings(String s) {
+    if (isBlank(s)) {
+      return null;
+    }
+    return Set.of(Food.valueOf(s));
   }
 
   @GetMapping
   public List<FugaziDto> get(HttpServletRequest request) {
     log.info("URL {}", request.getRequestURL());
-    log.info("URI {}", request.getQueryString());
+    log.info("Query {}", request.getQueryString());
     return Vulcan.forRepo(repo)
         .config(configuration())
         .build()

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
@@ -5,10 +5,10 @@ import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.va.api.health.autoconfig.configuration.JacksonConfig;
-import gov.va.api.lighthouse.vulcan.Mappings;
 import gov.va.api.lighthouse.vulcan.Vulcan;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration;
 import gov.va.api.lighthouse.vulcan.VulcanConfiguration.PagingConfiguration;
+import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import java.time.Instant;
 import java.util.List;
 import javax.servlet.http.HttpServletRequest;

--- a/src/test/java/gov/va/api/lighthouse/vulcan/mappings/DateMappingTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/mappings/DateMappingTest.java
@@ -6,7 +6,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import gov.va.api.lighthouse.vulcan.InvalidParameter;
+import gov.va.api.lighthouse.vulcan.InvalidRequest;
 import gov.va.api.lighthouse.vulcan.fugazi.FugaziEntity;
 import gov.va.api.lighthouse.vulcan.mappings.DateMapping.DateFidelity;
 import gov.va.api.lighthouse.vulcan.mappings.DateMapping.DateOperator;
@@ -171,7 +171,7 @@ class DateMappingTest {
       })
   @NullAndEmptySource
   void parsedParametersThrowExceptionForIllegalValues(String parameterValue) {
-    assertThatExceptionOfType(InvalidParameter.class)
+    assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () -> {
               var sd = new SearchableDate("x", parameterValue);
@@ -183,7 +183,7 @@ class DateMappingTest {
   void specificationForThrowsExceptionIfParameterIsRepeatedMoreThanTwice() {
     var r = mock(HttpServletRequest.class);
     when(r.getParameterValues("date")).thenReturn(new String[] {"1", "2", "3"});
-    assertThatExceptionOfType(InvalidParameter.class)
+    assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
                 DateMapping.<FugaziEntity, Long>builder()

--- a/src/test/java/gov/va/api/lighthouse/vulcan/mappings/DateMappingTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/mappings/DateMappingTest.java
@@ -1,4 +1,4 @@
-package gov.va.api.lighthouse.vulcan;
+package gov.va.api.lighthouse.vulcan.mappings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -6,11 +6,12 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import gov.va.api.lighthouse.vulcan.DateMapping.DateFidelity;
-import gov.va.api.lighthouse.vulcan.DateMapping.DateOperator;
-import gov.va.api.lighthouse.vulcan.DateMapping.FixedAmountDateApproximation;
-import gov.va.api.lighthouse.vulcan.DateMapping.SearchableDate;
+import gov.va.api.lighthouse.vulcan.InvalidParameter;
 import gov.va.api.lighthouse.vulcan.fugazi.FugaziEntity;
+import gov.va.api.lighthouse.vulcan.mappings.DateMapping.DateFidelity;
+import gov.va.api.lighthouse.vulcan.mappings.DateMapping.DateOperator;
+import gov.va.api.lighthouse.vulcan.mappings.DateMapping.FixedAmountDateApproximation;
+import gov.va.api.lighthouse.vulcan.mappings.DateMapping.SearchableDate;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;

--- a/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
@@ -2,7 +2,6 @@ package gov.va.api.lighthouse.vulcan.mappings;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import gov.va.api.lighthouse.vulcan.InvalidRequest;
 import java.util.function.BiFunction;
@@ -105,17 +104,17 @@ public class TokenParameterTest {
 
   @Test
   public void checkNullThrowsIllegalState() {
-    assertThrows(
-        IllegalStateException.class,
-        () ->
-            anySystemExplicitCodeToken
-                .behavior()
-                .onAnySystemAndExplicitCode(null)
-                .onExplicitSystemAndAnyCode(null)
-                .onExplicitSystemAndExplicitCode(null)
-                .onNoSystemAndExplicitCode(null)
-                .build()
-                .execute());
+    assertThatExceptionOfType(IllegalStateException.class)
+        .isThrownBy(
+            () ->
+                anySystemExplicitCodeToken
+                    .behavior()
+                    .onAnySystemAndExplicitCode(null)
+                    .onExplicitSystemAndAnyCode(null)
+                    .onExplicitSystemAndExplicitCode(null)
+                    .onNoSystemAndExplicitCode(null)
+                    .build()
+                    .execute());
   }
 
   @Test
@@ -164,17 +163,19 @@ public class TokenParameterTest {
 
   @Test
   public void parseBlank() {
-    assertThrows(InvalidRequest.class, () -> TokenParameter.parse("x", ""));
+    assertThatExceptionOfType(InvalidRequest.class).isThrownBy(() -> TokenParameter.parse("x", ""));
   }
 
   @Test
   public void parseNull() {
-    assertThrows(InvalidRequest.class, () -> TokenParameter.parse("x", null));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(() -> TokenParameter.parse("x", null));
   }
 
   @Test
   public void parsePipe() {
-    assertThrows(InvalidRequest.class, () -> TokenParameter.parse("x", "|"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(() -> TokenParameter.parse("x", "|"));
   }
 
   @ParameterizedTest

--- a/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
@@ -48,52 +48,56 @@ public class TokenParameterTest {
 
   @Test
   public void booleanSupport() {
-    assertThat(noSystemExplicitCodeToken.hasAnySystem()).isEqualTo(false);
-    assertThat(noSystemExplicitCodeToken.hasExplicitSystem()).isEqualTo(false);
-    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
-    assertThat(noSystemExplicitCodeToken.hasExplicitlyNoSystem()).isEqualTo(true);
-    assertThat(noSystemExplicitCodeToken.hasAnyCode()).isEqualTo(false);
-    assertThat(noSystemExplicitCodeToken.hasExplicitCode()).isEqualTo(true);
-    assertThat(noSystemExplicitCodeToken.hasSupportedCode("code")).isEqualTo(true);
-    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
-    assertThat(noSystemExplicitCodeToken.isSystemExplicitAndUnsupported("system")).isEqualTo(false);
-    assertThat(noSystemExplicitCodeToken.isCodeExplicitAndUnsupported("code")).isEqualTo(false);
-    assertThat(explicitSystemExplicitCodeToken.hasAnySystem()).isEqualTo(false);
-    assertThat(explicitSystemExplicitCodeToken.hasExplicitSystem()).isEqualTo(true);
-    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(true);
-    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("notsystem")).isEqualTo(false);
-    assertThat(explicitSystemExplicitCodeToken.hasExplicitlyNoSystem()).isEqualTo(false);
-    assertThat(explicitSystemExplicitCodeToken.hasAnyCode()).isEqualTo(false);
-    assertThat(explicitSystemExplicitCodeToken.hasExplicitCode()).isEqualTo(true);
-    assertThat(explicitSystemExplicitCodeToken.hasSupportedCode(("code"))).isEqualTo(true);
-    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(true);
+    assertThat(noSystemExplicitCodeToken.hasAnySystem()).isFalse();
+    assertThat(noSystemExplicitCodeToken.hasExplicitSystem()).isFalse();
+    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isFalse();
+    assertThat(noSystemExplicitCodeToken.hasExplicitlyNoSystem()).isTrue();
+    assertThat(noSystemExplicitCodeToken.hasAnyCode()).isFalse();
+    assertThat(noSystemExplicitCodeToken.hasExplicitCode()).isTrue();
+    assertThat(noSystemExplicitCodeToken.hasSupportedCode("code")).isTrue();
+    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isFalse();
+    assertThat(noSystemExplicitCodeToken.isSystemExplicitAndUnsupported("system")).isFalse();
+    assertThat(noSystemExplicitCodeToken.isCodeExplicitAndUnsupported("code")).isFalse();
+    assertThat(noSystemExplicitCodeToken.isCodeExplicitlySetAndOneOf(Codes.code)).isTrue();
+    assertThat(noSystemExplicitCodeToken.isCodeExplicitlySetAndOneOf("code", "other"));
+    assertThat(noSystemExplicitCodeToken.isCodeExplicitlySetAndOneOf("nope", "other")).isFalse();
+    assertThat(explicitSystemExplicitCodeToken.hasAnySystem()).isFalse();
+    assertThat(explicitSystemExplicitCodeToken.hasExplicitSystem()).isTrue();
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("system")).isTrue();
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("notsystem")).isFalse();
+    assertThat(explicitSystemExplicitCodeToken.hasExplicitlyNoSystem()).isFalse();
+    assertThat(explicitSystemExplicitCodeToken.hasAnyCode()).isFalse();
+    assertThat(explicitSystemExplicitCodeToken.hasExplicitCode()).isTrue();
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedCode(("code"))).isTrue();
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("system")).isTrue();
     assertThat(explicitSystemExplicitCodeToken.isSystemExplicitAndUnsupported(("system")))
-        .isEqualTo(false);
-    assertThat(explicitSystemExplicitCodeToken.isCodeExplicitAndUnsupported("code"))
-        .isEqualTo(false);
-    assertThat(anySystemExplicitCodeToken.hasAnySystem()).isEqualTo(true);
-    assertThat(anySystemExplicitCodeToken.hasExplicitSystem()).isEqualTo(false);
-    assertThat(anySystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
-    assertThat(anySystemExplicitCodeToken.hasExplicitlyNoSystem()).isEqualTo(false);
-    assertThat(anySystemExplicitCodeToken.hasAnyCode()).isEqualTo(false);
-    assertThat(anySystemExplicitCodeToken.hasExplicitCode()).isEqualTo(true);
-    assertThat(anySystemExplicitCodeToken.hasSupportedCode("code")).isEqualTo(true);
-    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
-    assertThat(anySystemExplicitCodeToken.isSystemExplicitAndUnsupported("notsystem"))
-        .isEqualTo(false);
-    assertThat(noSystemExplicitCodeToken.isCodeExplicitAndUnsupported("notcode")).isEqualTo(true);
-    assertThat(explicitSystemAnyCodeToken.hasAnySystem()).isEqualTo(false);
-    assertThat(explicitSystemAnyCodeToken.hasExplicitSystem()).isEqualTo(true);
-    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("system")).isEqualTo(true);
-    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("notsystem")).isEqualTo(false);
-    assertThat(explicitSystemAnyCodeToken.hasExplicitlyNoSystem()).isEqualTo(false);
-    assertThat(explicitSystemAnyCodeToken.hasAnyCode()).isEqualTo(true);
-    assertThat(explicitSystemAnyCodeToken.hasExplicitCode()).isEqualTo(false);
-    assertThat(explicitSystemAnyCodeToken.hasSupportedCode("code")).isEqualTo(false);
-    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("system")).isEqualTo(true);
-    assertThat(explicitSystemAnyCodeToken.isSystemExplicitAndUnsupported("notsystem"))
-        .isEqualTo(true);
-    assertThat(explicitSystemAnyCodeToken.isCodeExplicitAndUnsupported("notcode")).isEqualTo(false);
+        .isFalse();
+    assertThat(explicitSystemExplicitCodeToken.isCodeExplicitAndUnsupported("code")).isFalse();
+    assertThat(explicitSystemExplicitCodeToken.isSystemExplicitlySetAndOneOf("system", "other"))
+        .isTrue();
+    assertThat(explicitSystemExplicitCodeToken.isSystemExplicitlySetAndOneOf("nope", "other"))
+        .isFalse();
+    assertThat(anySystemExplicitCodeToken.hasAnySystem()).isTrue();
+    assertThat(anySystemExplicitCodeToken.hasExplicitSystem()).isFalse();
+    assertThat(anySystemExplicitCodeToken.hasSupportedSystem("system")).isFalse();
+    assertThat(anySystemExplicitCodeToken.hasExplicitlyNoSystem()).isFalse();
+    assertThat(anySystemExplicitCodeToken.hasAnyCode()).isFalse();
+    assertThat(anySystemExplicitCodeToken.hasExplicitCode()).isTrue();
+    assertThat(anySystemExplicitCodeToken.hasSupportedCode("code")).isTrue();
+    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isFalse();
+    assertThat(anySystemExplicitCodeToken.isSystemExplicitAndUnsupported("notsystem")).isFalse();
+    assertThat(noSystemExplicitCodeToken.isCodeExplicitAndUnsupported("notcode")).isTrue();
+    assertThat(explicitSystemAnyCodeToken.hasAnySystem()).isFalse();
+    assertThat(explicitSystemAnyCodeToken.hasExplicitSystem()).isTrue();
+    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("system")).isTrue();
+    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("notsystem")).isFalse();
+    assertThat(explicitSystemAnyCodeToken.hasExplicitlyNoSystem()).isFalse();
+    assertThat(explicitSystemAnyCodeToken.hasAnyCode()).isTrue();
+    assertThat(explicitSystemAnyCodeToken.hasExplicitCode()).isFalse();
+    assertThat(explicitSystemAnyCodeToken.hasSupportedCode("code")).isFalse();
+    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("system")).isTrue();
+    assertThat(explicitSystemAnyCodeToken.isSystemExplicitAndUnsupported("notsystem")).isTrue();
+    assertThat(explicitSystemAnyCodeToken.isCodeExplicitAndUnsupported("notcode")).isFalse();
   }
 
   @Test
@@ -176,5 +180,9 @@ public class TokenParameterTest {
     assertThat(TokenParameter.parse("x", "system|")).isEqualTo(explicitSystemAnyCodeToken);
     assertThat(TokenParameter.parse("x", "system|code")).isEqualTo(explicitSystemExplicitCodeToken);
     assertThat(TokenParameter.parse("x", "code")).isEqualTo(anySystemExplicitCodeToken);
+  }
+
+  enum Codes {
+    code;
   }
 }

--- a/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import gov.va.api.lighthouse.vulcan.InvalidParameter;
+import gov.va.api.lighthouse.vulcan.InvalidRequest;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
@@ -164,17 +164,17 @@ public class TokenParameterTest {
 
   @Test
   public void parseBlank() {
-    assertThrows(InvalidParameter.class, () -> TokenParameter.parse("x", ""));
+    assertThrows(InvalidRequest.class, () -> TokenParameter.parse("x", ""));
   }
 
   @Test
   public void parseNull() {
-    assertThrows(InvalidParameter.class, () -> TokenParameter.parse("x", null));
+    assertThrows(InvalidRequest.class, () -> TokenParameter.parse("x", null));
   }
 
   @Test
   public void parsePipe() {
-    assertThrows(InvalidParameter.class, () -> TokenParameter.parse("x", "|"));
+    assertThrows(InvalidRequest.class, () -> TokenParameter.parse("x", "|"));
   }
 
   @ParameterizedTest

--- a/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
@@ -1,0 +1,180 @@
+package gov.va.api.lighthouse.vulcan.mappings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import gov.va.api.lighthouse.vulcan.InvalidParameter;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+public class TokenParameterTest {
+  TokenParameter noSystemExplicitCodeToken =
+      TokenParameter.builder()
+          .code("code")
+          .system(null)
+          .mode(TokenParameter.Mode.NO_SYSTEM_EXPLICIT_CODE)
+          .build();
+
+  TokenParameter explicitSystemAnyCodeToken =
+      TokenParameter.builder()
+          .code(null)
+          .system("system")
+          .mode(TokenParameter.Mode.EXPLICIT_SYSTEM_ANY_CODE)
+          .build();
+
+  TokenParameter explicitSystemExplicitCodeToken =
+      TokenParameter.builder()
+          .code("code")
+          .system("system")
+          .mode(TokenParameter.Mode.EXPLICIT_SYSTEM_EXPLICIT_CODE)
+          .build();
+
+  TokenParameter anySystemExplicitCodeToken =
+      TokenParameter.builder()
+          .code("code")
+          .system(null)
+          .mode(TokenParameter.Mode.ANY_SYSTEM_EXPLICIT_CODE)
+          .build();
+
+  Function<String, String> anySystemAndExplicitCode = c -> "c is for " + c;
+
+  Function<String, String> explicitSystemAndAnyCode = s -> "s is for " + s;
+
+  Function<String, String> noSystemAndExplicitCode = c -> "c is for " + c;
+
+  BiFunction<String, String, String> explicitSystemAndExplicitCode =
+      (s, c) -> "s is for " + s + ", c is for " + c;
+
+  @Test
+  public void booleanSupport() {
+    assertThat(noSystemExplicitCodeToken.hasAnySystem()).isEqualTo(false);
+    assertThat(noSystemExplicitCodeToken.hasExplicitSystem()).isEqualTo(false);
+    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
+    assertThat(noSystemExplicitCodeToken.hasExplicitlyNoSystem()).isEqualTo(true);
+    assertThat(noSystemExplicitCodeToken.hasAnyCode()).isEqualTo(false);
+    assertThat(noSystemExplicitCodeToken.hasExplicitCode()).isEqualTo(true);
+    assertThat(noSystemExplicitCodeToken.hasSupportedCode("code")).isEqualTo(true);
+    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
+    assertThat(noSystemExplicitCodeToken.isSystemExplicitAndUnsupported("system")).isEqualTo(false);
+    assertThat(noSystemExplicitCodeToken.isCodeExplicitAndUnsupported("code")).isEqualTo(false);
+    assertThat(explicitSystemExplicitCodeToken.hasAnySystem()).isEqualTo(false);
+    assertThat(explicitSystemExplicitCodeToken.hasExplicitSystem()).isEqualTo(true);
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(true);
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("notsystem")).isEqualTo(false);
+    assertThat(explicitSystemExplicitCodeToken.hasExplicitlyNoSystem()).isEqualTo(false);
+    assertThat(explicitSystemExplicitCodeToken.hasAnyCode()).isEqualTo(false);
+    assertThat(explicitSystemExplicitCodeToken.hasExplicitCode()).isEqualTo(true);
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedCode(("code"))).isEqualTo(true);
+    assertThat(explicitSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(true);
+    assertThat(explicitSystemExplicitCodeToken.isSystemExplicitAndUnsupported(("system")))
+        .isEqualTo(false);
+    assertThat(explicitSystemExplicitCodeToken.isCodeExplicitAndUnsupported("code"))
+        .isEqualTo(false);
+    assertThat(anySystemExplicitCodeToken.hasAnySystem()).isEqualTo(true);
+    assertThat(anySystemExplicitCodeToken.hasExplicitSystem()).isEqualTo(false);
+    assertThat(anySystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
+    assertThat(anySystemExplicitCodeToken.hasExplicitlyNoSystem()).isEqualTo(false);
+    assertThat(anySystemExplicitCodeToken.hasAnyCode()).isEqualTo(false);
+    assertThat(anySystemExplicitCodeToken.hasExplicitCode()).isEqualTo(true);
+    assertThat(anySystemExplicitCodeToken.hasSupportedCode("code")).isEqualTo(true);
+    assertThat(noSystemExplicitCodeToken.hasSupportedSystem("system")).isEqualTo(false);
+    assertThat(anySystemExplicitCodeToken.isSystemExplicitAndUnsupported("notsystem"))
+        .isEqualTo(false);
+    assertThat(noSystemExplicitCodeToken.isCodeExplicitAndUnsupported("notcode")).isEqualTo(true);
+    assertThat(explicitSystemAnyCodeToken.hasAnySystem()).isEqualTo(false);
+    assertThat(explicitSystemAnyCodeToken.hasExplicitSystem()).isEqualTo(true);
+    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("system")).isEqualTo(true);
+    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("notsystem")).isEqualTo(false);
+    assertThat(explicitSystemAnyCodeToken.hasExplicitlyNoSystem()).isEqualTo(false);
+    assertThat(explicitSystemAnyCodeToken.hasAnyCode()).isEqualTo(true);
+    assertThat(explicitSystemAnyCodeToken.hasExplicitCode()).isEqualTo(false);
+    assertThat(explicitSystemAnyCodeToken.hasSupportedCode("code")).isEqualTo(false);
+    assertThat(explicitSystemAnyCodeToken.hasSupportedSystem("system")).isEqualTo(true);
+    assertThat(explicitSystemAnyCodeToken.isSystemExplicitAndUnsupported("notsystem"))
+        .isEqualTo(true);
+    assertThat(explicitSystemAnyCodeToken.isCodeExplicitAndUnsupported("notcode")).isEqualTo(false);
+  }
+
+  @Test
+  public void checkNullThrowsIllegalState() {
+    assertThrows(
+        IllegalStateException.class,
+        () ->
+            anySystemExplicitCodeToken
+                .behavior()
+                .onAnySystemAndExplicitCode(null)
+                .onExplicitSystemAndAnyCode(null)
+                .onExplicitSystemAndExplicitCode(null)
+                .onNoSystemAndExplicitCode(null)
+                .build()
+                .execute());
+  }
+
+  @Test
+  public void execute() {
+    assertThat(
+            anySystemExplicitCodeToken
+                .behavior()
+                .onAnySystemAndExplicitCode(anySystemAndExplicitCode)
+                .onExplicitSystemAndAnyCode(explicitSystemAndAnyCode)
+                .onExplicitSystemAndExplicitCode(explicitSystemAndExplicitCode)
+                .onNoSystemAndExplicitCode(noSystemAndExplicitCode)
+                .build()
+                .execute())
+        .isEqualTo("c is for code");
+    assertThat(
+            explicitSystemExplicitCodeToken
+                .behavior()
+                .onExplicitSystemAndAnyCode(explicitSystemAndAnyCode)
+                .onAnySystemAndExplicitCode(anySystemAndExplicitCode)
+                .onExplicitSystemAndExplicitCode(explicitSystemAndExplicitCode)
+                .onNoSystemAndExplicitCode(noSystemAndExplicitCode)
+                .build()
+                .execute())
+        .isEqualTo("s is for system, c is for code");
+    assertThat(
+            explicitSystemAnyCodeToken
+                .behavior()
+                .onExplicitSystemAndExplicitCode(explicitSystemAndExplicitCode)
+                .onAnySystemAndExplicitCode(anySystemAndExplicitCode)
+                .onExplicitSystemAndAnyCode(explicitSystemAndAnyCode)
+                .onNoSystemAndExplicitCode(noSystemAndExplicitCode)
+                .build()
+                .execute())
+        .isEqualTo("s is for system");
+    assertThat(
+            noSystemExplicitCodeToken
+                .behavior()
+                .onAnySystemAndExplicitCode(anySystemAndExplicitCode)
+                .onExplicitSystemAndAnyCode(explicitSystemAndAnyCode)
+                .onExplicitSystemAndExplicitCode(explicitSystemAndExplicitCode)
+                .onNoSystemAndExplicitCode(noSystemAndExplicitCode)
+                .build()
+                .execute())
+        .isEqualTo("c is for code");
+  }
+
+  @Test
+  public void parseBlank() {
+    assertThrows(InvalidParameter.class, () -> TokenParameter.parse("x", ""));
+  }
+
+  @Test
+  public void parseNull() {
+    assertThrows(InvalidParameter.class, () -> TokenParameter.parse("x", null));
+  }
+
+  @Test
+  public void parsePipe() {
+    assertThrows(InvalidParameter.class, () -> TokenParameter.parse("x", "|"));
+  }
+
+  @Test
+  public void validParse() {
+    assertThat(TokenParameter.parse("x", "|code")).isEqualTo(noSystemExplicitCodeToken);
+    assertThat(TokenParameter.parse("x", "system|")).isEqualTo(explicitSystemAnyCodeToken);
+    assertThat(TokenParameter.parse("x", "system|code")).isEqualTo(explicitSystemExplicitCodeToken);
+    assertThat(TokenParameter.parse("x", "code")).isEqualTo(anySystemExplicitCodeToken);
+  }
+}

--- a/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/mappings/TokenParameterTest.java
@@ -1,12 +1,15 @@
 package gov.va.api.lighthouse.vulcan.mappings;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import gov.va.api.lighthouse.vulcan.InvalidParameter;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TokenParameterTest {
   TokenParameter noSystemExplicitCodeToken =
@@ -172,6 +175,21 @@ public class TokenParameterTest {
   @Test
   public void parsePipe() {
     assertThrows(InvalidParameter.class, () -> TokenParameter.parse("x", "|"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"code", "|code", "system|code", "system|"})
+  public void throwsExceptionWhenBehaviorIsNotConfigured(String value) {
+    var token = TokenParameter.parse("x", value);
+    var behavior =
+        token
+            .behavior()
+            .onNoSystemAndExplicitCode(null)
+            .onExplicitSystemAndExplicitCode(null)
+            .onExplicitSystemAndAnyCode(null)
+            .onAnySystemAndExplicitCode(null)
+            .build();
+    assertThatExceptionOfType(IllegalStateException.class).isThrownBy(() -> behavior.execute());
   }
 
   @Test


### PR DESCRIPTION
Adds rule support
- repackaged mapping implementations in mappings package
- configurable default search behavior if no specifications can be created from request parameters
- standard rules
