### PR TITLE
API-6945-csv-support-for-medReq-intent

### DIFF
--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
@@ -204,6 +204,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
   }
 
   /** Create a token list mapping where field name is constant . */
+  @Deprecated(since = "1.0.9", forRemoval = true)
   public Mappings<EntityT> tokenList(
       String parameterName,
       String fieldName,
@@ -213,6 +214,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
   }
 
   /** Create a token list mapping where parameter and field name are the same. */
+  @Deprecated(since = "1.0.9", forRemoval = true)
   public Mappings<EntityT> tokenList(
       String parameterAndFieldName,
       Predicate<TokenParameter> supportedToken,
@@ -221,6 +223,7 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
   }
 
   /** Create a token list mapping where all aspects are configurable. */
+  @Deprecated(since = "1.0.9", forRemoval = true)
   public Mappings<EntityT> tokenList(
       String parameterName,
       Function<TokenParameter, Collection<String>> fieldNameSelector,

--- a/src/test/java/gov/va/api/lighthouse/vulcan/VulcanTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/VulcanTest.java
@@ -202,15 +202,17 @@ class VulcanTest {
   @ParameterizedTest
   @ValueSource(
       strings = {
-        "/fugazi?foodtoken=|",
-        "/fugazi?foodtokencsv=|",
-        "/fugazi?foodtokencsv=NACHOS,|",
-        "/fugazi?xdate=nope",
-        "/fugazi?xdate=no2006"
+        "?foodtoken=|",
+        "?foodtokencsv=|",
+        "?foodSpecToken=|",
+        "?foodtokencsv=NACHOS,|",
+        "?foodSpecToken=NACHOS,|",
+        "?xdate=nope",
+        "?xdate=no2006"
       })
   @SneakyThrows
-  void invalidParameterSearchs(String uri) {
-    mvc.perform(get(uri)).andExpect(status().isBadRequest());
+  void invalidParameterSearchs(String query) {
+    mvc.perform(get("/fugazi" + query)).andExpect(status().isBadRequest());
   }
 
   @SuppressWarnings("SpellCheckingInspection")
@@ -278,6 +280,7 @@ class VulcanTest {
 
   @Test
   void mappingToken() {
+    // Deprecated
     assertThat(req("/fugazi?foodtoken=")).isEmpty();
     assertThat(req("/fugazi?foodtoken=PIZZA")).isEmpty();
     assertThat(req("/fugazi?foodtoken=http://movie-theater|NACHOS")).isEmpty();
@@ -289,13 +292,23 @@ class VulcanTest {
     assertThat(req("/fugazi?foodtoken=http://food|"))
         .containsExactlyInAnyOrder(
             nachos2005, moreNachos2005, tacos2005, tacos2006, tacos2007, tacos2008);
+    // New Fancy Boi
+    assertThat(req("/fugazi?foodSpecToken=")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=PIZZA")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=http://movie-theater|NACHOS")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=NACHOS")).containsExactly(nachos2005);
+    assertThat(req("/fugazi?foodSpecToken=TACOS"))
+        .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008);
     assertThat(req("/fugazi?foodSpecToken=http://food|TACOS"))
         .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008);
-    assertThat(req("/fugazi?foodSpecToken=http://movie-theater|NACHOS")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=http://food|"))
+        .containsExactlyInAnyOrder(
+            nachos2005, moreNachos2005, tacos2005, tacos2006, tacos2007, tacos2008);
   }
 
   @Test
   void mappingTokenList() {
+    // Deprecated
     assertThat(req("/fugazi?foodtokencsv=")).isEmpty();
     assertThat(req("/fugazi?foodtokencsv=,")).isEmpty();
     assertThat(req("/fugazi?foodtokencsv=PIZZA")).isEmpty();
@@ -312,6 +325,25 @@ class VulcanTest {
     assertThat(req("/fugazi?foodtokencsv=http://food|TACOS,NACHOS"))
         .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008, nachos2005);
     assertThat(req("/fugazi?foodtokencsv=http://food|"))
+        .containsExactlyInAnyOrder(
+            nachos2005, moreNachos2005, tacos2005, tacos2006, tacos2007, tacos2008);
+    // New Fancy Boi
+    assertThat(req("/fugazi?foodSpecToken=")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=,")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=PIZZA")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=http://movie-theater|NACHOS")).isEmpty();
+    assertThat(req("/fugazi?foodSpecToken=NACHOS")).containsExactly(nachos2005);
+    assertThat(req("/fugazi?foodSpecToken=TACOS"))
+        .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008);
+    assertThat(req("/fugazi?foodSpecToken=http://food|TACOS"))
+        .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008);
+    assertThat(req("/fugazi?foodSpecToken=http://food|TACOS,http://nope|NACHOS"))
+        .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008);
+    assertThat(req("/fugazi?foodSpecToken=http://food|TACOS,http://food|NACHOS"))
+        .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008, nachos2005);
+    assertThat(req("/fugazi?foodSpecToken=http://food|TACOS,NACHOS"))
+        .containsExactlyInAnyOrder(tacos2005, tacos2006, tacos2007, tacos2008, nachos2005);
+    assertThat(req("/fugazi?foodSpecToken=http://food|"))
         .containsExactlyInAnyOrder(
             nachos2005, moreNachos2005, tacos2005, tacos2006, tacos2007, tacos2008);
   }


### PR DESCRIPTION
# [API-6945](https://vajira.max.gov/browse/API-6945)
This is required to support csv for the intent parameter in MedicationRequest. With the currently existing CSV list token mapping, we would either circuit break or we would try to search for a column that doesn't exist which is undesired behavior. The intent params only function is to determine whether to allow a medsta or medord search. By updating the token mapping to support csv, we can set the specification to null without shorting out after checking if the token is supported.