### PR TITLE
API-6945-reject-unknown-modifiers

### DIFF
--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
@@ -105,29 +105,11 @@ public class Rules {
   public static class IfParameterRuleBuilder {
     private final String parameter;
 
-    /** Require at least one of the given parameters to be specified. */
-    public Rule thenAlsoAtLeastOneParameterOf(String... requiredParameters) {
-      return (ctx) -> {
-        if (isNotBlank(ctx.request().getParameter(parameter))) {
-          atLeastOneParameterOf(requiredParameters).check(ctx);
-        }
-      };
-    }
-
-    /** Forbid all of the given parameters from being specified. */
-    public Rule thenForbidParameters(String... forbiddenParameters) {
-      return (ctx) -> {
-        if (isNotBlank(ctx.request().getParameter(parameter))) {
-          forbiddenParameters(forbiddenParameters).check(ctx);
-        }
-      };
-    }
-
     /**
      * Forbid any unknown parameter modifiers. Known modifiers are determined both by the mappings
      * themselves, but also any provided to the method.
      */
-    public Rule thenForbidUnknownModifiers(String... additionalSupportedModifiers) {
+    public Rule thenAllowOnlyKnownModifiers(String... additionalSupportedModifiers) {
       return (ctx) -> {
         var supportedParameters =
             ctx.config().supportedParameters().stream()
@@ -148,6 +130,24 @@ public class Rules {
                         p, ctx.request().getParameter(p), "Modifier not allowed.");
                   }
                 });
+      };
+    }
+
+    /** Require at least one of the given parameters to be specified. */
+    public Rule thenAlsoAtLeastOneParameterOf(String... requiredParameters) {
+      return (ctx) -> {
+        if (isNotBlank(ctx.request().getParameter(parameter))) {
+          atLeastOneParameterOf(requiredParameters).check(ctx);
+        }
+      };
+    }
+
+    /** Forbid all of the given parameters from being specified. */
+    public Rule thenForbidParameters(String... forbiddenParameters) {
+      return (ctx) -> {
+        if (isNotBlank(ctx.request().getParameter(parameter))) {
+          forbiddenParameters(forbiddenParameters).check(ctx);
+        }
       };
     }
   }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
@@ -1,10 +1,13 @@
 package gov.va.api.lighthouse.vulcan;
 
+import static java.lang.String.join;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.Arrays;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -97,6 +100,7 @@ public class Rules {
     };
   }
 
+  @Value
   @RequiredArgsConstructor
   public static class IfParameterRuleBuilder {
     private final String parameter;
@@ -116,6 +120,34 @@ public class Rules {
         if (isNotBlank(ctx.request().getParameter(parameter))) {
           forbiddenParameters(forbiddenParameters).check(ctx);
         }
+      };
+    }
+
+    /**
+     * Forbid any unknown parameter modifiers. Known modifiers are determined both by the mappings
+     * themselves, but also any provided to the method.
+     */
+    public Rule thenForbidUnknownModifiers(String... additionalSupportedModifiers) {
+      return (ctx) -> {
+        var supportedParameters =
+            ctx.config().supportedParameters().stream()
+                .filter(p -> p.startsWith(parameter()))
+                .filter(p -> p.contains(":"))
+                .collect(toList());
+        var allowedParameters =
+            Stream.concat(
+                    supportedParameters.stream(),
+                    Arrays.stream(additionalSupportedModifiers).map(m -> join(":", parameter(), m)))
+                .collect(toList());
+        ctx.request().getParameterMap().keySet().stream()
+            .filter(p -> p.startsWith(parameter()))
+            .forEach(
+                p -> {
+                  if (!allowedParameters.contains(p)) {
+                    throw InvalidRequest.badParameter(
+                        p, ctx.request().getParameter(p), "Modifier not allowed.");
+                  }
+                });
       };
     }
   }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
@@ -2,6 +2,7 @@ package gov.va.api.lighthouse.vulcan;
 
 import static java.lang.String.join;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.Arrays;
@@ -115,12 +116,12 @@ public class Rules {
             ctx.config().supportedParameters().stream()
                 .filter(p -> p.startsWith(parameter()))
                 .filter(p -> p.contains(":"))
-                .collect(toList());
+                .collect(toSet());
         var allowedParameters =
             Stream.concat(
                     supportedParameters.stream(),
                     Arrays.stream(additionalSupportedModifiers).map(m -> join(":", parameter(), m)))
-                .collect(toList());
+                .collect(toSet());
         ctx.request().getParameterMap().keySet().stream()
             .filter(p -> p.startsWith(parameter()))
             .forEach(

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ReferenceMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ReferenceMapping.java
@@ -93,9 +93,7 @@ public class ReferenceMapping<EntityT> implements Mapping<EntityT> {
 
   @Override
   public List<String> supportedParameterNames() {
-    return Stream.concat(
-            Stream.of(parameterName(), parameterName() + ":identifier"),
-            asParametersWithTypeModifier())
+    return Stream.concat(Stream.of(parameterName()), asParametersWithTypeModifier())
         .collect(Collectors.toList());
   }
 }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ReferenceMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/ReferenceMapping.java
@@ -93,7 +93,9 @@ public class ReferenceMapping<EntityT> implements Mapping<EntityT> {
 
   @Override
   public List<String> supportedParameterNames() {
-    return Stream.concat(Stream.of(parameterName()), asParametersWithTypeModifier())
+    return Stream.concat(
+            Stream.of(parameterName(), parameterName() + ":identifier"),
+            asParametersWithTypeModifier())
         .collect(Collectors.toList());
   }
 }

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
@@ -96,6 +96,15 @@ class RulesTest {
   }
 
   @Test
+  void ifParameterThenForbidUnknownModifiers() {
+    var rule = Rules.ifParameter("nacho").thenForbidUnknownModifiers("friday", "libre");
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(() -> rule.check(requestWithParameters("nacho:wednesday")));
+    rule.check(requestWithParameters("nacho:friday"));
+    rule.check(requestWithParameters("nacho:libre"));
+  }
+
+  @Test
   void parametersAlwaysSpecifiedTogether() {
     Rules.parametersAlwaysSpecifiedTogether("foo", "bar").check(requestWithParameters("whatever"));
     Rules.parametersAlwaysSpecifiedTogether("foo", "bar")

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.mock.web.MockHttpServletRequest;
 
 class RulesTest {
-
   @Test
   void atLeastOneParameterOf() {
     Rules.atLeastOneParameterOf("foo", "bar").check(requestWithParameters("foo"));
@@ -46,6 +45,15 @@ class RulesTest {
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () -> Rules.forbiddenParameters("foo", "bar").check(requestWithParameters("bar")));
+  }
+
+  @Test
+  void ifParameterThenAllowOnlyKnownModifiers() {
+    var rule = Rules.ifParameter("nacho").thenAllowOnlyKnownModifiers("friday", "libre");
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(() -> rule.check(requestWithParameters("nacho:wednesday")));
+    rule.check(requestWithParameters("nacho:friday"));
+    rule.check(requestWithParameters("nacho:libre"));
   }
 
   @Test
@@ -93,15 +101,6 @@ class RulesTest {
                 Rules.ifParameter("foo")
                     .thenForbidParameters("bar", "ack")
                     .check(requestWithParameters("foo", "ack")));
-  }
-
-  @Test
-  void ifParameterThenForbidUnknownModifiers() {
-    var rule = Rules.ifParameter("nacho").thenForbidUnknownModifiers("friday", "libre");
-    assertThatExceptionOfType(InvalidRequest.class)
-        .isThrownBy(() -> rule.check(requestWithParameters("nacho:wednesday")));
-    rule.check(requestWithParameters("nacho:friday"));
-    rule.check(requestWithParameters("nacho:libre"));
   }
 
   @Test
@@ -159,6 +158,7 @@ class RulesTest {
   @RequiredArgsConstructor
   private static class FugaziRuleContext implements RuleContext {
     HttpServletRequest request;
+
     VulcanConfiguration<?> config;
   }
 }


### PR DESCRIPTION
# [API-6945](https://vajira.max.gov/browse/API-6945)
This PR moves the reject unknown modifier logic out of the allergy intolerance controller in dq so that it can be used in all controllers. In addition, this adds missing support for the 'identifier' modifier on reference parameters by default.