### PR TITLE
API-6945-selectInList-varchar

### DIFF
--- a/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Specifications.java
@@ -1,7 +1,9 @@
 package gov.va.api.lighthouse.vulcan;
 
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.stream.Collector;
 import java.util.stream.Collector.Characteristics;
 import javax.persistence.criteria.CriteriaBuilder.In;
@@ -41,7 +43,11 @@ public class Specifications {
   }
 
   public static <E> Specification<E> select(String fieldName, Object value) {
-    return selectInList(fieldName, List.of(value));
+    return selectInList(fieldName, value);
+  }
+
+  public static <E> Specification<E> selectInList(String fieldName, Object... values) {
+    return selectInList(fieldName, Arrays.stream(values).collect(toSet()));
   }
 
   /** Produces a specification than explicitly handles a lists of 0 and 1. */

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
@@ -17,13 +17,11 @@ import gov.va.api.lighthouse.vulcan.mappings.Mappings;
 import gov.va.api.lighthouse.vulcan.mappings.ReferenceParameter;
 import gov.va.api.lighthouse.vulcan.mappings.TokenParameter;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -133,9 +131,12 @@ public class FugaziController {
         .onNoSystemAndExplicitCode(c -> Specifications.<FugaziEntity>select("food", c))
         .onExplicitSystemAndAnyCode(
             s ->
+                // FugaziEntity defines "food" as a string.
                 Specifications.<FugaziEntity>selectInList(
                     "food",
-                    Arrays.stream(Food.values()).map(Enum::toString).collect(Collectors.toSet())))
+                    Food.TACOS.toString(),
+                    Food.EVEN_MORE_NACHOS.toString(),
+                    Food.NACHOS.toString()))
         .build()
         .execute();
   }


### PR DESCRIPTION
# [API-6945](https://vajira.max.gov/browse/API-6945)
Adds a selectInList method that takes varchar as input.