### PR TITLE
API-000-support-param-without-modifier

### DIFF
--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
@@ -112,6 +112,10 @@ public class Rules {
      */
     public Rule thenAllowOnlyKnownModifiers(String... additionalSupportedModifiers) {
       return (ctx) -> {
+        // If parameter has no modifier, continue
+        if (ctx.request().getParameter(parameter()) != null) {
+          return;
+        }
         var supportedParameters =
             ctx.config().supportedParameters().stream()
                 .filter(p -> p.startsWith(parameter()))

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
@@ -52,6 +52,7 @@ class RulesTest {
     var rule = Rules.ifParameter("nacho").thenAllowOnlyKnownModifiers("friday", "libre");
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(() -> rule.check(requestWithParameters("nacho:wednesday")));
+    rule.check(requestWithParameters("nacho"));
     rule.check(requestWithParameters("nacho:friday"));
     rule.check(requestWithParameters("nacho:libre"));
   }


### PR DESCRIPTION
# [API-000](https://vajira.max.gov/browse/API-000)
Fix bug where rule was causing failures when no modifier was present.