### PR TITLE
API-3444: add fieldNameSelector support to string searches

### DIFF
--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/Mappings.java
@@ -134,8 +134,17 @@ public class Mappings<EntityT> implements Supplier<List<Mapping<EntityT>>> {
 
   /** Create a string mapping where request and field name are different. */
   public Mappings<EntityT> string(String parameterName, String fieldName) {
+    return string(parameterName, s -> singletonList(fieldName));
+  }
+
+  /** Create a string mapping where the value should match one of many field names. */
+  public Mappings<EntityT> string(
+      String parameterName, Function<String, Collection<String>> fieldNameSelector) {
     return add(
-        StringMapping.<EntityT>builder().parameterName(parameterName).fieldName(fieldName).build());
+        StringMapping.<EntityT>builder()
+            .parameterName(parameterName)
+            .fieldNameSelector(fieldNameSelector)
+            .build());
   }
 
   /** Create a token mapping where all aspects are configurable. */

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
@@ -99,7 +99,7 @@ public class StringMapping<EntityT> implements Mapping<EntityT> {
 
   private Collection<String> fieldNames(String value) {
     var fieldNames = fieldNameSelector().apply(value);
-    if (fieldNames.isEmpty()) {
+    if (fieldNames == null || fieldNames.isEmpty()) {
       throw CircuitBreaker.noResultsWillBeFound(
           asContainsParameterName(), value, "No database column defined.");
     }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/mappings/StringMapping.java
@@ -3,9 +3,13 @@ package gov.va.api.lighthouse.vulcan.mappings;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import gov.va.api.lighthouse.vulcan.CircuitBreaker;
 import gov.va.api.lighthouse.vulcan.Mapping;
+import gov.va.api.lighthouse.vulcan.Specifications;
+import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
 import javax.servlet.http.HttpServletRequest;
 import lombok.Builder;
 import lombok.Value;
@@ -24,10 +28,9 @@ import org.springframework.data.jpa.domain.Specification;
 @Value
 @Builder
 public class StringMapping<EntityT> implements Mapping<EntityT> {
-
   String parameterName;
 
-  String fieldName;
+  Function<String, Collection<String>> fieldNameSelector;
 
   @Override
   public boolean appliesTo(HttpServletRequest request) {
@@ -53,17 +56,28 @@ public class StringMapping<EntityT> implements Mapping<EntityT> {
     if (isBlank(value)) {
       return null;
     }
-    return (Specification<EntityT>)
-        (root, criteriaQuery, criteriaBuilder) ->
-            criteriaBuilder.like(
-                criteriaBuilder.lower(root.get(fieldName)),
-                "%" + value.toLowerCase(Locale.ENGLISH) + "%");
+    Collection<String> fieldNames = fieldNames(value);
+    return fieldNames.stream()
+        .map(
+            fieldName ->
+                (Specification<EntityT>)
+                    (root, criteriaQuery, criteriaBuilder) ->
+                        criteriaBuilder.like(
+                            criteriaBuilder.lower(root.get(fieldName)),
+                            "%" + value.toLowerCase(Locale.ENGLISH) + "%"))
+        .collect(Specifications.any());
   }
 
   private Specification<EntityT> clauseForExactMatch(HttpServletRequest request) {
     String value = request.getParameter(asExactParameterName());
-    return (Specification<EntityT>)
-        (root, criteriaQuery, criteriaBuilder) -> criteriaBuilder.equal(root.get(fieldName), value);
+    Collection<String> fieldNames = fieldNames(value);
+    return fieldNames.stream()
+        .map(
+            fieldName ->
+                (Specification<EntityT>)
+                    (root, criteriaQuery, criteriaBuilder) ->
+                        criteriaBuilder.equal(root.get(fieldName), value))
+        .collect(Specifications.any());
   }
 
   private Specification<EntityT> clauseForStartsWithMatch(HttpServletRequest request) {
@@ -71,11 +85,25 @@ public class StringMapping<EntityT> implements Mapping<EntityT> {
     if (isBlank(value)) {
       return null;
     }
-    return (Specification<EntityT>)
-        (root, criteriaQuery, criteriaBuilder) ->
-            criteriaBuilder.like(
-                criteriaBuilder.lower(root.get(fieldName)),
-                value.toLowerCase(Locale.ENGLISH) + "%");
+    Collection<String> fieldNames = fieldNames(value);
+    return fieldNames.stream()
+        .map(
+            fieldName ->
+                (Specification<EntityT>)
+                    (root, criteriaQuery, criteriaBuilder) ->
+                        criteriaBuilder.like(
+                            criteriaBuilder.lower(root.get(fieldName)),
+                            value.toLowerCase(Locale.ENGLISH) + "%"))
+        .collect(Specifications.any());
+  }
+
+  private Collection<String> fieldNames(String value) {
+    var fieldNames = fieldNameSelector().apply(value);
+    if (fieldNames.isEmpty()) {
+      throw CircuitBreaker.noResultsWillBeFound(
+          asContainsParameterName(), value, "No database column defined.");
+    }
+    return fieldNames;
   }
 
   @Override

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziController.java
@@ -67,6 +67,7 @@ public class FugaziController {
             Mappings.forEntity(FugaziEntity.class)
                 .string("name")
                 .string("xname", "name")
+                .string("foodOrBase", p -> (Set.of("food", "base")))
                 .value("namevalue", "name")
                 .value("namevalue", "name")
                 .value("millis", v -> Instant.parse(v).toEpochMilli())

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziDto.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziDto.java
@@ -19,4 +19,10 @@ public class FugaziDto {
     TACOS,
     EVEN_MORE_NACHOS
   }
+
+  public enum Base {
+    CHIPS,
+    TORTILLAS,
+    BREAD
+  }
 }

--- a/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziEntity.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/fugazi/FugaziEntity.java
@@ -24,6 +24,7 @@ public class FugaziEntity {
   @Id @GeneratedValue @Column @NotNull @EqualsAndHashCode.Include long id;
   @Column @NotNull String name;
   @Column String food;
+  @Column String base;
   @Column @NotNull Instant date;
   @Column long millis;
   @Column String payload;


### PR DESCRIPTION
Adds support to match a `string` value to one of multiple fields.

For example:
```
  .string("name", f -> Set.of("familyName", "givenName"))
```
looks for the name value in either familyName OR givenName columns.

This functionality supports the initial implementation of the Practitioner _search by name_ use case.