### PR TITLE
API-7972: Rules now account for string modifiers

### DIFF
--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
@@ -25,13 +25,17 @@ public class Rules {
    * <p>If the parameter is not known to be supported, it is returned anyways so the Rules can be
    * enforced.
    */
-  private static List<String> expanded(String startsWith, List<String> source) {
-    if (source == null || source.isEmpty()) {
-      return List.of(startsWith);
+  private static List<String> expanded(
+      String baseParameterName, List<String> allSupportedParameters) {
+    if (allSupportedParameters == null || allSupportedParameters.isEmpty()) {
+      return List.of(baseParameterName);
     }
-    var result = source.stream().filter(s -> s.startsWith(startsWith)).collect(toList());
+    var result =
+        allSupportedParameters.stream()
+            .filter(s -> s.equals(baseParameterName) || s.startsWith(baseParameterName + ":"))
+            .collect(toList());
     if (result.isEmpty()) {
-      result.add(startsWith);
+      result.add(baseParameterName);
     }
     return result;
   }

--- a/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
+++ b/src/main/java/gov/va/api/lighthouse/vulcan/Rules.java
@@ -91,8 +91,7 @@ public class Rules {
     if (specifiedParameters.contains(parameter)) {
       return true;
     }
-    var modified = specifiedParameters.stream().filter(isModifiedVersionOf(parameter)).findFirst();
-    return modified.isPresent();
+    return specifiedParameters.stream().anyMatch(isModifiedVersionOf(parameter));
   }
 
   /**

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
@@ -25,6 +25,18 @@ class RulesTest {
   }
 
   @Test
+  void atLeastOneParameterOfWithModifiers() {
+    Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("foo"));
+    Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str"));
+    Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:contains"));
+    Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:exact"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:nope")));
+  }
+
+  @Test
   void forbidUnknownParameters() {
     Rules.forbidUnknownParameters().check(requestWithParameters("foo"));
     Rules.forbidUnknownParameters().check(requestWithParameters("bar"));
@@ -45,6 +57,23 @@ class RulesTest {
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () -> Rules.forbiddenParameters("foo", "bar").check(requestWithParameters("bar")));
+  }
+
+  @Test
+  void forbiddenParametersWithModifiers() {
+    Rules.forbiddenParameters("foo", "str").check(requestWithParameters("bar"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () -> Rules.forbiddenParameters("foo", "str").check(requestWithParameters("str")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.forbiddenParameters("foo", "str")
+                    .check(requestWithParameters("str:contains")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.forbiddenParameters("foo", "str").check(requestWithParameters("str:exact")));
   }
 
   @Test
@@ -83,6 +112,34 @@ class RulesTest {
   }
 
   @Test
+  void ifParameterThenAlsoAtLeastOneParameterOfWithModifiers() {
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("str")
+        .check(requestWithParameters("whatever"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("str")
+        .check(requestWithParameters("foo", "str"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("str")
+        .check(requestWithParameters("foo", "str:contains"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("str")
+        .check(requestWithParameters("foo", "str:exact"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenAlsoAtLeastOneParameterOf("str")
+                    .check(requestWithParameters("foo", "whatever")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenAlsoAtLeastOneParameterOf("str")
+                    .check(requestWithParameters("foo", "str:nope")));
+  }
+
+  @Test
   void ifParameterThenForbidParameters() {
     Rules.ifParameter("foo")
         .thenForbidParameters("bar", "ack")
@@ -105,6 +162,32 @@ class RulesTest {
   }
 
   @Test
+  void ifParameterThenForbidParametersWithModifiers() {
+    Rules.ifParameter("foo").thenForbidParameters("str").check(requestWithParameters("whatever"));
+    Rules.ifParameter("foo")
+        .thenForbidParameters("str")
+        .check(requestWithParameters("foo", "whatever"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenForbidParameters("str")
+                    .check(requestWithParameters("foo", "str")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenForbidParameters("str")
+                    .check(requestWithParameters("foo", "str:contains")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenForbidParameters("str")
+                    .check(requestWithParameters("foo", "str:exact")));
+  }
+
+  @Test
   void parametersAlwaysSpecifiedTogether() {
     Rules.parametersAlwaysSpecifiedTogether("foo", "bar").check(requestWithParameters("whatever"));
     Rules.parametersAlwaysSpecifiedTogether("foo", "bar")
@@ -122,6 +205,37 @@ class RulesTest {
   }
 
   @Test
+  void parametersAlwaysSpecifiedTogetherWithModifiers() {
+    Rules.parametersAlwaysSpecifiedTogether("foo", "str").check(requestWithParameters("whatever"));
+    Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("foo", "str"));
+    Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("foo", "str:contains"));
+    Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("foo", "str:exact"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("foo")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("str")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("str:contains")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("foo", "str:nope")));
+  }
+
+  @Test
   void parametersNeverSpecifiedTogether() {
     Rules.parametersNeverSpecifiedTogether("foo", "bar").check(requestWithParameters("whatever"));
     Rules.parametersNeverSpecifiedTogether("foo", "bar").check(requestWithParameters("foo"));
@@ -131,6 +245,31 @@ class RulesTest {
             () ->
                 Rules.parametersNeverSpecifiedTogether("foo", "bar")
                     .check(requestWithParameters("foo", "bar")));
+  }
+
+  @Test
+  void parametersNeverSpecifiedTogetherWithModifiers() {
+    Rules.parametersNeverSpecifiedTogether("foo", "str").check(requestWithParameters("whatever"));
+    Rules.parametersNeverSpecifiedTogether("foo", "str").check(requestWithParameters("foo"));
+    Rules.parametersNeverSpecifiedTogether("foo", "str").check(requestWithParameters("str"));
+    Rules.parametersNeverSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("str:contains"));
+    Rules.parametersNeverSpecifiedTogether("foo", "str").check(requestWithParameters("str:exact"));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersNeverSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("foo", "str")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersNeverSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("foo", "str:contains")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersNeverSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("foo", "str:exact")));
   }
 
   private FugaziRuleContext requestWithParameters(String... parameters) {
@@ -150,7 +289,12 @@ class RulesTest {
                     .baseUrlStrategy(useRequestUrl())
                     .build())
             .defaultQuery(Vulcan.returnNothing())
-            .mappings(Mappings.forEntity(FugaziEntity.class).value("foo").value("bar").get())
+            .mappings(
+                Mappings.forEntity(FugaziEntity.class)
+                    .value("foo")
+                    .value("bar")
+                    .string("str")
+                    .get())
             .build();
     return new FugaziRuleContext(req, config);
   }

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
@@ -34,6 +34,10 @@ class RulesTest {
         .isThrownBy(
             () ->
                 Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:nope")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str-nope")));
   }
 
   @Test
@@ -62,6 +66,7 @@ class RulesTest {
   @Test
   void forbiddenParametersWithModifiers() {
     Rules.forbiddenParameters("foo", "str").check(requestWithParameters("bar"));
+    Rules.forbiddenParameters("foo", "str").check(requestWithParameters("str-whatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () -> Rules.forbiddenParameters("foo", "str").check(requestWithParameters("str")));
@@ -137,6 +142,12 @@ class RulesTest {
                 Rules.ifParameter("foo")
                     .thenAlsoAtLeastOneParameterOf("str")
                     .check(requestWithParameters("foo", "str:nope")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenAlsoAtLeastOneParameterOf("str")
+                    .check(requestWithParameters("foo", "str-whatever")));
   }
 
   @Test
@@ -164,6 +175,9 @@ class RulesTest {
   @Test
   void ifParameterThenForbidParametersWithModifiers() {
     Rules.ifParameter("foo").thenForbidParameters("str").check(requestWithParameters("whatever"));
+    Rules.ifParameter("foo")
+        .thenForbidParameters("str")
+        .check(requestWithParameters("str-whatever"));
     Rules.ifParameter("foo")
         .thenForbidParameters("str")
         .check(requestWithParameters("foo", "whatever"));
@@ -208,6 +222,8 @@ class RulesTest {
   void parametersAlwaysSpecifiedTogetherWithModifiers() {
     Rules.parametersAlwaysSpecifiedTogether("foo", "str").check(requestWithParameters("whatever"));
     Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("str-whatever"));
+    Rules.parametersAlwaysSpecifiedTogether("foo", "str")
         .check(requestWithParameters("foo", "str"));
     Rules.parametersAlwaysSpecifiedTogether("foo", "str")
         .check(requestWithParameters("foo", "str:contains"));
@@ -233,6 +249,11 @@ class RulesTest {
             () ->
                 Rules.parametersAlwaysSpecifiedTogether("foo", "str")
                     .check(requestWithParameters("foo", "str:nope")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("foo", "str-whatever")));
   }
 
   @Test
@@ -255,6 +276,8 @@ class RulesTest {
     Rules.parametersNeverSpecifiedTogether("foo", "str")
         .check(requestWithParameters("str:contains"));
     Rules.parametersNeverSpecifiedTogether("foo", "str").check(requestWithParameters("str:exact"));
+    Rules.parametersNeverSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("foo", "str-whatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->

--- a/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
+++ b/src/test/java/gov/va/api/lighthouse/vulcan/RulesTest.java
@@ -30,10 +30,11 @@ class RulesTest {
     Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str"));
     Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:contains"));
     Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:exact"));
+    Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:whatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
-                Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("str:nope")));
+                Rules.atLeastOneParameterOf("foo", "str").check(requestWithParameters("strnope")));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
@@ -67,6 +68,7 @@ class RulesTest {
   void forbiddenParametersWithModifiers() {
     Rules.forbiddenParameters("foo", "str").check(requestWithParameters("bar"));
     Rules.forbiddenParameters("foo", "str").check(requestWithParameters("str-whatever"));
+    Rules.forbiddenParameters("foo", "str").check(requestWithParameters("strwhatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () -> Rules.forbiddenParameters("foo", "str").check(requestWithParameters("str")));
@@ -79,6 +81,11 @@ class RulesTest {
         .isThrownBy(
             () ->
                 Rules.forbiddenParameters("foo", "str").check(requestWithParameters("str:exact")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.forbiddenParameters("foo", "str")
+                    .check(requestWithParameters("str:whatever")));
   }
 
   @Test
@@ -130,6 +137,9 @@ class RulesTest {
     Rules.ifParameter("foo")
         .thenAlsoAtLeastOneParameterOf("str")
         .check(requestWithParameters("foo", "str:exact"));
+    Rules.ifParameter("foo")
+        .thenAlsoAtLeastOneParameterOf("str")
+        .check(requestWithParameters("foo", "str:whatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
@@ -141,13 +151,13 @@ class RulesTest {
             () ->
                 Rules.ifParameter("foo")
                     .thenAlsoAtLeastOneParameterOf("str")
-                    .check(requestWithParameters("foo", "str:nope")));
+                    .check(requestWithParameters("foo", "strnope")));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
                 Rules.ifParameter("foo")
                     .thenAlsoAtLeastOneParameterOf("str")
-                    .check(requestWithParameters("foo", "str-whatever")));
+                    .check(requestWithParameters("foo", "str-nope")));
   }
 
   @Test
@@ -180,6 +190,9 @@ class RulesTest {
         .check(requestWithParameters("str-whatever"));
     Rules.ifParameter("foo")
         .thenForbidParameters("str")
+        .check(requestWithParameters("strwhatever"));
+    Rules.ifParameter("foo")
+        .thenForbidParameters("str")
         .check(requestWithParameters("foo", "whatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
@@ -199,6 +212,12 @@ class RulesTest {
                 Rules.ifParameter("foo")
                     .thenForbidParameters("str")
                     .check(requestWithParameters("foo", "str:exact")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.ifParameter("foo")
+                    .thenForbidParameters("str")
+                    .check(requestWithParameters("foo", "str:whatever")));
   }
 
   @Test
@@ -229,6 +248,8 @@ class RulesTest {
         .check(requestWithParameters("foo", "str:contains"));
     Rules.parametersAlwaysSpecifiedTogether("foo", "str")
         .check(requestWithParameters("foo", "str:exact"));
+    Rules.parametersAlwaysSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("foo", "str:whatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
@@ -248,12 +269,12 @@ class RulesTest {
         .isThrownBy(
             () ->
                 Rules.parametersAlwaysSpecifiedTogether("foo", "str")
-                    .check(requestWithParameters("foo", "str:nope")));
+                    .check(requestWithParameters("foo", "str-whatever")));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
                 Rules.parametersAlwaysSpecifiedTogether("foo", "str")
-                    .check(requestWithParameters("foo", "str-whatever")));
+                    .check(requestWithParameters("foo", "strwhatever")));
   }
 
   @Test
@@ -278,6 +299,8 @@ class RulesTest {
     Rules.parametersNeverSpecifiedTogether("foo", "str").check(requestWithParameters("str:exact"));
     Rules.parametersNeverSpecifiedTogether("foo", "str")
         .check(requestWithParameters("foo", "str-whatever"));
+    Rules.parametersNeverSpecifiedTogether("foo", "str")
+        .check(requestWithParameters("foo", "strwhatever"));
     assertThatExceptionOfType(InvalidRequest.class)
         .isThrownBy(
             () ->
@@ -293,6 +316,11 @@ class RulesTest {
             () ->
                 Rules.parametersNeverSpecifiedTogether("foo", "str")
                     .check(requestWithParameters("foo", "str:exact")));
+    assertThatExceptionOfType(InvalidRequest.class)
+        .isThrownBy(
+            () ->
+                Rules.parametersNeverSpecifiedTogether("foo", "str")
+                    .check(requestWithParameters("foo", "str:whatever")));
   }
 
   private FugaziRuleContext requestWithParameters(String... parameters) {


### PR DESCRIPTION
Vulcan Rules now account for string modifiers, e.g. `:contains` and `:exact`.